### PR TITLE
Fix beastmaster

### DIFF
--- a/code/modules/vtmb/npc/beastmaster.dm
+++ b/code/modules/vtmb/npc/beastmaster.dm
@@ -140,7 +140,7 @@ SUBSYSTEM_DEF(beastmastering)
 			ClickOn(targa)
 	else
 		if(follow && isturf(beastmaster.loc))
-			if(z != beastmaster.z)
+			if( (z != beastmaster.z) & (get_dist(beastmaster.loc, loc) <= 10) )
 				forceMove(get_turf(beastmaster))
 			else
 				var/reqsteps = round((SSbeastmastering.next_fire-world.time)/totalshit)


### PR DESCRIPTION
## About The Pull Request
Fixes beastmastering so that you can properly tell them to stay or follow you. Removes the ability for beasts to teleport to you when far away, and changes the cross-Z-level teleportation to only work when 10 or less tiles away from the beast. 

## Why It's Good For The Game
Bugfix that people have been complaining about with the commands. A strategy with a 100% win rate is to gather your minions somewhere, and then teleport them over when you get into trouble in combat. This is a buzzkill, and you should need to bring your minions with you if you want to use them.

## Changelog
:cl:
fix: Beasts now obey Stay/Follow commands.
tweak: Beasts will no longer teleport to you on the same z-level when more than 15 tiles away. Beasts will only teleport to you over z-levels if 10 tiles or less away.
/:cl:
