### PR TITLE
Salubri discipline changes

### DIFF
--- a/code/modules/spells/spell_types/construct_spells.dm
+++ b/code/modules/spells/spell_types/construct_spells.dm
@@ -114,6 +114,19 @@
 	action_background_icon_state = "bg_demon"
 
 
+/obj/effect/proc_holder/spell/targeted/forcewall/salubri
+	name = "Shepherd's Wall"
+	desc = " The third eye opens and flares a bright white, illuminating a barely-visible ward around the Unicorn and his charge. No foe may breach this sacred shield. The Salubri himself must stand among those he defends as he generates this barrier; he cannot guard them from afar."
+	school = "transmutation"
+	charge_max = 400
+	clothes_req = FALSE
+	invocation = "none"
+	invocation_type = "none"
+	wall_type = /obj/effect/forcefield/cult
+	action_icon = 'icons/mob/actions/actions_cult.dmi'
+	action_icon_state = "cultforcewall"
+	action_background_icon_state = "bg_demon"
+
 
 /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shift
 	name = "Phase Shift"

--- a/code/modules/spells/spell_types/forcewall.dm
+++ b/code/modules/spells/spell_types/forcewall.dm
@@ -23,6 +23,16 @@
 		new wall_type(get_step(user, SOUTH),user)
 
 
+/obj/effect/proc_holder/spell/targeted/forcewall/salubri/cast(list/targets,mob/user = usr)
+	new wall_type(get_step(user, NORTH), user)
+	new wall_type(get_step(user, SOUTH), user)
+	new wall_type(get_step(user, EAST), user)
+	new wall_type(get_step(user, WEST), user)
+	new wall_type(get_step(get_step(user, NORTH), EAST), user) // Northeast
+	new wall_type(get_step(get_step(user, NORTH), WEST), user) // Northwest
+	new wall_type(get_step(get_step(user, SOUTH), EAST), user) // Southeast
+	new wall_type(get_step(get_step(user, SOUTH), WEST), user) // Southwest
+
 /obj/effect/forcefield/wizard
 	var/mob/wizard
 

--- a/code/modules/spells/spell_types/forcewall.dm
+++ b/code/modules/spells/spell_types/forcewall.dm
@@ -23,15 +23,19 @@
 		new wall_type(get_step(user, SOUTH),user)
 
 
-/obj/effect/proc_holder/spell/targeted/forcewall/salubri/cast(list/targets,mob/user = usr)
-	new wall_type(get_step(user, NORTH), user)
-	new wall_type(get_step(user, SOUTH), user)
-	new wall_type(get_step(user, EAST), user)
-	new wall_type(get_step(user, WEST), user)
-	new wall_type(get_step(get_step(user, NORTH), EAST), user) // Northeast
-	new wall_type(get_step(get_step(user, NORTH), WEST), user) // Northwest
-	new wall_type(get_step(get_step(user, SOUTH), EAST), user) // Southeast
-	new wall_type(get_step(get_step(user, SOUTH), WEST), user) // Southwest
+/obj/effect/proc_holder/spell/targeted/forcewall/salubri/cast(list/targets, mob/user = usr)
+	//[Lucia] TODO: when Disciplines are refactored, make this not terrible
+	if (iskindred(user))
+		var/mob/living/carbon/human/human_user = user
+		human_user.bloodpool = max(0, human_user.bloodpool - 1)
+		new wall_type(get_step(user, NORTH), user)
+		new wall_type(get_step(user, SOUTH), user)
+		new wall_type(get_step(user, EAST), user)
+		new wall_type(get_step(user, WEST), user)
+		new wall_type(get_step(get_step(user, NORTH), EAST), user) // Northeast
+		new wall_type(get_step(get_step(user, NORTH), WEST), user) // Northwest
+		new wall_type(get_step(get_step(user, SOUTH), EAST), user) // Southeast
+		new wall_type(get_step(get_step(user, SOUTH), WEST), user) // Southwest
 
 /obj/effect/forcefield/wizard
 	var/mob/wizard

--- a/code/modules/vtmb/disciplines.dm
+++ b/code/modules/vtmb/disciplines.dm
@@ -1640,7 +1640,7 @@
 						to_chat(caster, "<span class='warning'>You need to grab a kindred and stay still to use this power.</span>")
 						return
 			else
-				to_chat(caster, "<span class='warning'>You need to hold your victim properly to heal their soul.</span>")
+				to_chat(caster, "<span class='warning'>You need to hold your patient properly to heal their soul.</span>")
 				return
 
 /datum/discipline/melpominee

--- a/code/modules/vtmb/disciplines.dm
+++ b/code/modules/vtmb/disciplines.dm
@@ -1578,6 +1578,7 @@
 	clane_restricted = TRUE
 	dead_restricted = FALSE
 	var/datum/beam/current_beam
+	var/humanity_restored = 0
 
 /datum/discipline/valeren/activate(mob/living/target, mob/living/carbon/human/caster)
 	. = ..()
@@ -1617,6 +1618,7 @@
 			target.update_damage_overlays()
 			target.update_health_hud()
 		if(4)
+			ranged = FALSE
 			if(current_beam)
 				qdel(current_beam)
 			caster.Beam(target, icon_state="sm_arc", time = 50, maxdistance = 9, beam_type = /obj/effect/ebeam/medical)
@@ -1633,9 +1635,12 @@
 			if(caster.grab_state > GRAB_PASSIVE)
 				if(ishuman(caster.pulling))
 					var/mob/living/carbon/human/PB = caster.pulling
-					if(do_after(caster, 10 SECONDS) && iskindred(PB))
+					if(do_after(caster, 10 SECONDS) && iskindred(PB) && humanity_restored < 3)
 						to_chat(caster, "<span class='notice'>You healed [PB]'s soul slightly.</span>")
 						PB.AdjustHumanity(1, 10)
+						humanity_restored += 1
+					else if(humanity_restored >=3)
+						to_chat(caster, "<span class='warning'>You can't heal anymore souls this night.</span>")
 					else
 						to_chat(caster, "<span class='warning'>You need to grab a kindred and stay still to use this power.</span>")
 						return

--- a/code/modules/vtmb/disciplines.dm
+++ b/code/modules/vtmb/disciplines.dm
@@ -1588,6 +1588,7 @@
 			chemscan(caster, target)
 //			woundscan(caster, target, src)
 			to_chat(caster, "<b>[target]</b> has <b>[target.bloodpool]/[target.maxbloodpool]</b> blood points.")
+			to_chat(caster, "<b>[target]</b> has a rating of <b>[target.humanity]</b> on their path.")
 		if(2)
 			if(caster.grab_state > GRAB_PASSIVE)
 				if(ishuman(caster.pulling))

--- a/code/modules/vtmb/disciplines.dm
+++ b/code/modules/vtmb/disciplines.dm
@@ -1633,7 +1633,7 @@
 			if(caster.grab_state > GRAB_PASSIVE)
 				if(ishuman(caster.pulling))
 					var/mob/living/carbon/human/PB = caster.pulling
-					if((do_after(caster, 100,target=caster)) && iskindred(PB))
+					if(do_after(caster, 10 SECONDS) && iskindred(PB))
 						to_chat(caster, "<span class='notice'>You healed [PB]'s soul slightly.</span>")
 						PB.AdjustHumanity(1, 10)
 					else

--- a/code/modules/vtmb/vampire_clane/salubri.dm
+++ b/code/modules/vtmb/vampire_clane/salubri.dm
@@ -13,3 +13,6 @@
 
 /datum/discipline/valeren/post_gain(mob/living/carbon/human/H)
 	H.put_in_r_hand(new /obj/item/vamp/keys/salubri(H))
+	if(level >= 4)
+		var/obj/effect/proc_holder/spell/targeted/forcewall/salubri/FW = new(H)
+		H.mind.AddSpell(FW)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Salubri 2nd discipline is no longer going to instantly handcuff you, and the 4th will no longer instantly drain your entire bloodpool. 5th also does not revive the dead any longer.
Instead, the 2nd discipline allows you to make a kindred drowsy and a mortal to fall asleep for 30 seconds. 4th discipline allows slightly better healing than 3rd, and gives you the ability to create walls around yourself for protection for a short time.
5th discipline allows you to increase the humanity of other kindred.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It nerfs an extremely overpowered auto-win discipline and makes it more lore accurate.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: redid half of the valeren discipline
del: deleted some old valeren powers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
