### PR TITLE
Removing Vicissitude from Old Clan, Old Clan manor is Old Clan only.

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2013,8 +2013,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 							var/datum/discipline/D = new i
 							if(!D.clane_restricted)
 								disc4 += i
-							if(clane.name == "Old Clan Tzimisce" && D.name == "Vicissitude")
-								disc4 += i
 							qdel(D)
 					var/discipline4 = input(user, "Select fourth discipline", "Discipline Selection") as null|anything in disc4
 					if(discipline4)

--- a/code/modules/vtmb/disciplines.dm
+++ b/code/modules/vtmb/disciplines.dm
@@ -1193,7 +1193,6 @@
 	violates_masquerade = TRUE
 	clane_restricted = TRUE
 	dead_restricted = FALSE
-	var/exclusive_clan = "Old Clan Tzimisce"
 
 /datum/discipline/vicissitude/activate(mob/living/target, mob/living/carbon/human/caster)
 	. = ..()

--- a/code/modules/vtmb/jobs.dm
+++ b/code/modules/vtmb/jobs.dm
@@ -2002,7 +2002,7 @@
 	exp_type_department = EXP_TYPE_INDEPENDENT
 
 	kindred_only = TRUE
-	allowed_bloodlines = list("Old Clan Tzimisce", "Tzimisce")
+	allowed_bloodlines = list("Old Clan Tzimisce")
 	minimal_generation = 7
 
 	v_duty = "You are a Childe of the Voivode-in-Waiting, the ancient Tzimisce Elder who has rested beneath the Earth for an age longer than the city that now rests on their bones. Honor them in all your actions, and remember that you walk with their favor."
@@ -2044,7 +2044,7 @@
 	exp_type_department = EXP_TYPE_INDEPENDENT
 
 	kindred_only = TRUE
-	allowed_bloodlines = list("Old Clan Tzimisce", "Tzimisce")
+	allowed_bloodlines = list("Old Clan Tzimisce")
 	minimal_generation = 13	//Uncomment when players get exp enough
 
 	v_duty = "Whether you are of Voivode-in-Waiting's blood or if you've been honored, you are one of the Kin of the Voivode. Protect your Family, as your Family would protect you."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the Old Clan Tzimisce unable to learn vicissitude, Bogatyr and Voivode become Old Clan only.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More accurate to the Old Clan Tzimisce in the lore. Makes them more unique.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked Old Clan Tzimisce
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
