### PR TITLE
Disables embedding images in flavor text

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2336,6 +2336,11 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if("flavor_text")
 					var/new_flavor = input(user, "Choose your character's flavor text:", "Character Preference")  as text|null
 					if(new_flavor)
+						var/pattern = "<img src="
+						var/pos = findtext(new_flavor, pattern)
+						if(pos)
+							to_chat(src, "Embedding images is not allowed.")
+							return
 						if(length(new_flavor) > 3 * 512)
 							to_chat(user, "Too long...")
 						else

--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -31,6 +31,11 @@
 	set category = "IC"
 	var/flavor = input("Choose your new flavor text:") as text|null
 	if(flavor)
+		var/pattern = "<img src="
+		var/pos = findtext(flavor, pattern)
+		if(pos)
+			to_chat(src, "Embedding images is not allowed.")
+			return
 		if(length(flavor) > 3 * 512)
 			to_chat(src, "Too long...")
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the ability to put an image in your flavor text.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A lot of flavor text images are just pure AI slop, or extremely large, intruding on people's examines. This can be exploited too, by malicious parties who can put anything they want there. It is also often pure cringe. Without it we would be better off.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed the ability to add images to flavor text
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
