### PR TITLE
Removing Elysium Bloodhunts

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -86,10 +86,6 @@
 	if(force && HAS_TRAIT(user, TRAIT_PACIFISM))
 		to_chat(user, "<span class='warning'>You don't want to harm other living beings!</span>")
 		return
-
-	if(force)
-		user.check_elysium(FALSE)
-
 	if(item_flags & EYE_STAB && user.zone_selected == BODY_ZONE_PRECISE_EYES)
 		if(HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
 			M = user

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -967,9 +967,6 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 		if(HAS_TRAIT(user, TRAIT_PACIFISM))
 			to_chat(user, "<span class='notice'>You set [src] down gently on the ground.</span>")
 			return
-		user.check_elysium(FALSE)
-	if(istype(src, /obj/item/molotov))
-		user.check_elysium(TRUE)
 	return src
 
 /**

--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -79,8 +79,6 @@
 	if(HAS_TRAIT(user, TRAIT_PACIFISM))
 		to_chat(user, "<span class='warning'>You can't bring yourself to fire \the [src]! You don't want to risk harming anyone...</span>")
 		return
-	var/mob/living/L = user
-	L.check_elysium(TRUE)
 	if(user && user.get_active_held_item() == src) // Make sure our user is still holding us
 		var/turf/target_turf = get_turf(target)
 		if(target_turf)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -124,7 +124,6 @@
 	if(HAS_TRAIT(user, TRAIT_PACIFISM))
 		to_chat(user, "<span class='danger'>Throwing [pushed_mob] onto the table might hurt them!</span>")
 		return
-	user.check_elysium(FALSE)
 	var/added_passtable = FALSE
 	if((!pushed_mob.pass_flags) & PASSTABLE)
 		added_passtable = TRUE

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -75,8 +75,6 @@
 		to_chat(user, "<span class='warning'>You don't want to harm [target]!</span>")
 		return
 
-	user.check_elysium(FALSE)
-
 	var/obj/item/bodypart/affecting = user.zone_selected //Find what the player is aiming at
 
 	var/armor_block = 0 //Get the target's armor values for normal attack damage.

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -162,8 +162,6 @@
 				if(HAS_TRAIT(src, TRAIT_PACIFISM))
 					to_chat(src, "<span class='notice'>You gently let go of [throwable_mob].</span>")
 					return
-				if(HAS_TRAIT(src, TRAIT_ELYSIUM))
-					check_elysium(FALSE)
 	else
 		thrown_thing = I.on_thrown(src, target)
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1352,7 +1352,6 @@ GLOBAL_LIST_EMPTY(donation_races)
 	if(HAS_TRAIT(user, TRAIT_PACIFISM))
 		to_chat(user, "<span class='warning'>You don't want to harm [target]!</span>")
 		return FALSE
-	user.check_elysium(FALSE)
 	if(target.check_block())
 		target.visible_message("<span class='warning'>[target] blocks [user]'s attack!</span>", \
 						"<span class='userdanger'>You block [user]'s attack!</span>", "<span class='hear'>You hear a swoosh!</span>", COMBAT_MESSAGE_RANGE, user)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1946,7 +1946,6 @@
 			if (INTENT_HARM)
 				if (HAS_TRAIT(src, TRAIT_PACIFISM))
 					return FALSE
-				check_elysium(FALSE)
 				attack_result = style.harm_act(src, target)
 			if (INTENT_DISARM)
 				attack_result = style.disarm_act(src, target)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -116,8 +116,6 @@
 	if(user.grab_state >= GRAB_AGGRESSIVE && HAS_TRAIT(user, TRAIT_PACIFISM))
 		to_chat(user, "<span class='warning'>You don't want to risk hurting [src]!</span>")
 		return FALSE
-	if(user.grab_state >= GRAB_AGGRESSIVE)
-		user.check_elysium(FALSE)
 	grippedby(user)
 
 //proc to upgrade a simple pull into a more aggressive grab.

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -733,7 +733,6 @@
 		return
 	if(IsImmobilized())
 		return
-	user.check_elysium(TRUE)
 	return relaydrive(user, direction)
 
 /mob/living/simple_animal/deadchat_plays(mode = ANARCHY_MODE, cooldown = 12 SECONDS)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -276,8 +276,6 @@
 			if(chambered.harmful) // Is the bullet chambered harmful?
 				to_chat(user, "<span class='warning'>[src] is lethally chambered! You don't want to risk harming anyone...</span>")
 				return
-		if(HAS_TRAIT(user, TRAIT_ELYSIUM))
-			user.check_elysium(FALSE)
 		if(randomspread)
 			sprd = round((rand() - 0.5) * DUALWIELD_PENALTY_EXTRA_MULTIPLIER * (randomized_gun_spread + randomized_bonus_spread))
 		else //Smart spread
@@ -337,8 +335,6 @@
 				if(chambered.harmful) // Is the bullet chambered harmful?
 					to_chat(user, "<span class='warning'>[src] is lethally chambered! You don't want to risk harming anyone...</span>")
 					return
-			if(HAS_TRAIT(user, TRAIT_ELYSIUM))
-				user.check_elysium(FALSE)
 			sprd = round((rand() - 0.5) * DUALWIELD_PENALTY_EXTRA_MULTIPLIER * (randomized_gun_spread + randomized_bonus_spread))
 			before_firing(target,user)
 			if(!chambered.fire_casing(target, user, params, , suppressed, zone_override, sprd, src))

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -679,13 +679,6 @@
 //	explosion(T, -1, exp_heavy, exp_light, exp_flash, 0, flame_range = 0)
 	var/obj/effect/fire/R = new(get_turf(target))
 	R.color = color
-	if(istype(get_area(target), /area/vtm))
-		var/area/vtm/V = get_area(target)
-		if(V.zone_type == "masquerade")
-			if(isliving(firer))
-				var/mob/living/L = firer
-				L.check_elysium(TRUE)
-
 
 /obj/projectile/magic/aoe/fireball/baali
 	color = "#2dff00"

--- a/code/modules/vtmb/disciplines.dm
+++ b/code/modules/vtmb/disciplines.dm
@@ -139,8 +139,6 @@
 			return FALSE
 	if(HAS_TRAIT(caster, TRAIT_PACIFISM))
 		return FALSE
-	if(HAS_TRAIT(caster, TRAIT_ELYSIUM) && violates_masquerade)
-		caster.check_elysium(FALSE)
 	if(target.resistant_to_disciplines || target.spell_immunity)
 		to_chat(caster, "<span class='danger'>[target] resists your powers!</span>")
 		return FALSE

--- a/code/modules/vtmb/gamemodes/bloodhunt.dm
+++ b/code/modules/vtmb/gamemodes/bloodhunt.dm
@@ -8,7 +8,7 @@
 			var/area/A = get_area(H)
 			to_chat(usr, "[icon2html(getFlatIcon(H), usr)][H.true_real_name], [H.mind ? H.mind.assigned_role : "Citizen"]. Was last seen at [A.name]")
 
-/mob/living/proc/check_elysium(var/instant = FALSE)
+/*/mob/living/proc/check_elysium(var/instant = FALSE)
 	if(ishuman(src))
 		var/mob/living/carbon/human/human = src
 		if(human.obfuscate_level < 5)
@@ -42,7 +42,7 @@
 			SSbloodhunt.announce_hunted(src)
 			if(V)
 				V.break_elysium()
-
+*/
 SUBSYSTEM_DEF(bloodhunt)
 	name = "Blood Hunt"
 	init_order = INIT_ORDER_DEFAULT

--- a/code/modules/wod13/guns.dm
+++ b/code/modules/wod13/guns.dm
@@ -553,8 +553,6 @@
 	if(HAS_TRAIT(user, TRAIT_PACIFISM))
 		to_chat(user, "<span class='warning'>You can't bring yourself to fire \the [src]! You don't want to risk harming anyone...</span>")
 		return
-	var/mob/living/L = user
-	L.check_elysium(TRUE)
 	playsound(get_turf(user), 'code/modules/wod13/sounds/flamethrower.ogg', 50, TRUE)
 	visible_message("<span class='warning'>[user] fires [src]!</span>", "<span class='warning'>You fire [src]!</span>")
 	if(user && user.get_active_held_item() == src) // Make sure our user is still holding us

--- a/code/modules/wod13/melee.dm
+++ b/code/modules/wod13/melee.dm
@@ -310,7 +310,6 @@
 		return
 	if(target.IsParalyzed() || target.IsKnockdown() || target.IsStun())
 		return
-	user.check_elysium(TRUE)
 	if(!target.IsParalyzed() && iskindred(target) && !target.stakeimmune)
 		visible_message("<span class='warning'>[user] aims [src] straight to the [target]'s heart!</span>", "<span class='warning'>You aim [src] straight to the [target]'s heart!</span>")
 		if(do_after(user, 20, target))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes getting blood hunted automatically for doing mean things in the Elysium.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Sometimes even Princes get bloodhunted for something like throwing a rock. The mechanic makes you question if a Bloodhunt was placed with intent or if someone accidentally shot a gun in the elysium. It adds nothing to the game, and without it it will be better.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed elysium auto-bloodhunt
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
