### PR TITLE
disables DoC ambient loop

### DIFF
--- a/code/modules/wod13/ambient.dm
+++ b/code/modules/wod13/ambient.dm
@@ -427,7 +427,7 @@
 				var/mob/living/carbon/human/H = src
 				if(H.clane)
 					if(H.clane.name == "Daughters of Cacaphony")
-						cacaphony = TRUE
+						cacaphony = FALSE //This Variable was TRUE, which makes the DoC music loop play.
 
 			if(!cacaphony)
 				if(!(client && (client.prefs.toggles & SOUND_AMBIENCE)))


### PR DESCRIPTION

## About The Pull Request

changes the TRUE variable in ambient.dm to stop the cacophony ambient loop from playing

## Why It's Good For The Game

This curse provides no IC drawbacks and is purely an OOC annoyance. It also did not function like other music in the game and could not be disabled by any means like ambient music or lobby music.


## Changelog
:cl:
tweak: Changed the variable in Ambient.dm to disable the daughters of cacophony sound loop

/:cl:
