### PR TITLE
Fixes doubling Key of Alamut

### DIFF
--- a/code/modules/vtmb/artifacts.dm
+++ b/code/modules/vtmb/artifacts.dm
@@ -186,6 +186,8 @@
 /obj/item/vtm_artifact/key_of_alamut/get_powers()
 	..()
 	var/mob/living/carbon/human/H = owner
+		if(H.dna.species.brutemod == 0.3)
+			return
 	if(H.dna)
 		H.dna.species.brutemod = H.dna.species.brutemod-0.2
 		H.dna.species.burnmod = H.dna.species.burnmod-0.2
@@ -193,6 +195,8 @@
 /obj/item/vtm_artifact/key_of_alamut/remove_powers()
 	..()
 	var/mob/living/carbon/human/H = owner
+	if(H.dna.species.brutemod == 0.5)
+		return
 	if(H.dna)
 		H.dna.species.brutemod = H.dna.species.brutemod+0.2
 		H.dna.species.burnmod = H.dna.species.burnmod+0.2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This fixes the problematic aspect of key of alamut that was some were abusing by stacking two, in order to make themselves almost invulnerable to bullets.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Defense buffs are good, being immune to damage is bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: rebalanced Key of Alamut. Now, if you have two of them equipped, only one will work, and you need to unequip both, then re-equip one, to get the bonuses again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
