### PR TITLE
Fixes Generation XP Costs

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -510,7 +510,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if(generation_allowed)
 					if(generation_bonus)
 						dat += " (+[generation_bonus]/[min(6, generation-7)])"
-					if(true_experience >= 10 && generation_bonus < max(0, generation-7))
+					if(true_experience >= 20 && generation_bonus < max(0, generation-7))
 						dat += " <a href='?_src_=prefs;preference=generation;task=input'>Claim generation bonus (20)</a><BR>"
 					else
 						dat += "<BR>"
@@ -2320,8 +2320,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						if(clane.name == "Caitiff")
 							link_bug_fix = FALSE
 							return
-					if(true_experience >= 10)
-						true_experience = true_experience-10
+					if(true_experience >= 20)
+						true_experience = true_experience-20
 						generation_bonus = min(generation_bonus+1, max(0, generation-7))
 //					if(exper_plus)
 //						if(exper_plus > calculate_max_exper())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes Generation lowering XP cost to the 20 listed instead of 10
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
removes confusion, and new players can no longer dump every starting XP point on generation, making them upgrade some stats or disciplines.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked xp costs for generation lowering
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
