### PR TITLE
Grave fix

### DIFF
--- a/code/modules/ruins/lavalandruin_code/elephantgraveyard.dm
+++ b/code/modules/ruins/lavalandruin_code/elephantgraveyard.dm
@@ -136,22 +136,23 @@
 			new /obj/item/coin/gold(src)
 			new /obj/item/storage/wallet(src)
 		if(2)
-			new /obj/item/clothing/glasses/meson(src)
+			new /obj/item/quran(src)
 		if(3)
 			new /obj/item/coin/silver(src)
-			new /obj/item/shovel/spade(src)
+			new /obj/item/molotov(src)
 		if(4)
-			new /obj/item/storage/book/bible/booze(src)
+			new /obj/item/storage/book/bible(src)
+			new /obj/item/card/id/hunter(src)
 		if(5)
 			new /obj/item/clothing/neck/stethoscope(src)
 			new	/obj/item/scalpel(src)
 			new /obj/item/hemostat(src)
+			new /obj/item/melee/vampirearms/baseball/hand(src)
 
 		if(6)
-			new /obj/item/reagent_containers/glass/beaker(src)
-			new /obj/item/clothing/glasses/science(src)
+			new /obj/item/ravnos(src)
 		if(7)
-			new /obj/item/clothing/glasses/sunglasses(src)
+			new /obj/item/clothing/glasses/vampire/sun(src)
 			new /obj/item/clothing/mask/cigarette/rollie(src)
 		else
 			//nothing!
@@ -214,7 +215,7 @@
 /obj/structure/closet/crate/grave/lead_researcher/PopulateContents()  //ADVANCED GRAVEROBBING
 	..()
 	new /obj/effect/decal/cleanable/blood/gibs/old(src)
-	new /obj/item/book/granter/crafting_recipe/boneyard_notes(src)
+	new /obj/item/food/spaghetti/meatballspaghetti(src)
 
 /obj/effect/decal/remains/human/grave
 	turf_loc_check = FALSE


### PR DESCRIPTION
fixes bug I introduced.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes an unintended behaviour of mesons/a couple other old SS13 items spawning out of a mapped in grave if dug up. Changes loot list to accomodate a few other of these graves mapped around without mesons being unleashed.
Currently can't be dug with our shovels still, only old shovels.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Immersion.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added VTM items to lootlist
del: old items on lootlist

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
