### PR TITLE
Garou Balance + Animal Appreciation

### DIFF
--- a/code/modules/mob/living/carbon/werewolf/lupus.dm
+++ b/code/modules/mob/living/carbon/werewolf/lupus.dm
@@ -9,10 +9,12 @@
 	limb_destroyer = 1
 	has_limbs = 0
 //	dextrous = FALSE
+//	speed = -1.5     doesn't work on carbons
+//	var/move_delay_add = -1.5 // movement delay to add    also didn't work
 	melee_damage_lower = 20
 	melee_damage_upper = 20
-	health = 200
-	maxHealth = 200
+	health = 300
+	maxHealth = 300
 //	bodyparts = list(
 //		/obj/item/bodypart/chest,
 //		/obj/item/bodypart/head,
@@ -21,6 +23,9 @@
 //		/obj/item/bodypart/r_leg,
 //		/obj/item/bodypart/l_leg,
 //		)
+
+	/datum/movespeed_modifier/lupusform
+	multiplicative_slowdown = -1.2
 
 /mob/living/carbon/werewolf/lupus/update_icons()
 	cut_overlays()
@@ -34,13 +39,13 @@
 		icon_state = "[sprite_color]"
 
 	switch(getFireLoss()+getBruteLoss())
-		if(25 to 50)
+		if(50 to 100)
 			var/mutable_appearance/damage_overlay = mutable_appearance(icon, "damage1[laid_down ? "_rest" : ""]")
 			add_overlay(damage_overlay)
-		if(50 to 75)
+		if(100 to 200)
 			var/mutable_appearance/damage_overlay = mutable_appearance(icon, "damage2[laid_down ? "_rest" : ""]")
 			add_overlay(damage_overlay)
-		if(75 to INFINITY)
+		if(200 to INFINITY)
 			var/mutable_appearance/damage_overlay = mutable_appearance(icon, "damage3[laid_down ? "_rest" : ""]")
 			add_overlay(damage_overlay)
 

--- a/code/modules/mob/living/carbon/werewolf/transformation.dm
+++ b/code/modules/mob/living/carbon/werewolf/transformation.dm
@@ -95,6 +95,7 @@
 					lupus_form.mind = trans.mind
 					lupus_form.update_blood_hud()
 					transfer_damage(trans, lupus_form)
+					lupus_form.add_movespeed_modifier(/datum/movespeed_modifier/lupusform)
 					trans.forceMove(src)
 					transformating = FALSE
 					animate(trans, transform = null, color = "#FFFFFF", time = 1)
@@ -132,6 +133,7 @@
 					crinos_form.mind = trans.mind
 					crinos_form.update_blood_hud()
 					transfer_damage(trans, crinos_form)
+					crinos_form.add_movespeed_modifier(/datum/movespeed_modifier/crinosform)
 					trans.forceMove(src)
 					transformating = FALSE
 					animate(trans, transform = null, color = "#FFFFFF", time = 1)
@@ -169,6 +171,8 @@
 					human_form.mind = trans.mind
 					human_form.update_blood_hud()
 					transfer_damage(trans, human_form)
+					human_form.remove_movespeed_modifier(/datum/movespeed_modifier/crinosform)
+					human_form.remove_movespeed_modifier(/datum/movespeed_modifier/lupusform)
 					trans.forceMove(src)
 					transformating = FALSE
 					animate(trans, transform = null, color = "#FFFFFF", time = 1)

--- a/code/modules/mob/living/carbon/werewolf/werewolf.dm
+++ b/code/modules/mob/living/carbon/werewolf/werewolf.dm
@@ -190,8 +190,9 @@
 	hud_type = /datum/hud/werewolf
 	melee_damage_lower = 40
 	melee_damage_upper = 40
-	health = 200
-	maxHealth = 200
+	health = 500
+	maxHealth = 500
+//	speed = -1  doesn't work on carbons
 	var/obj/item/r_store = null
 	var/obj/item/l_store = null
 	var/pounce_cooldown = 0
@@ -208,6 +209,9 @@
 		)
 
 	werewolf_armor = 25
+
+	/datum/movespeed_modifier/crinosform
+	multiplicative_slowdown = -0.5
 
 /mob/living/carbon/werewolf/crinos/Initialize()
 	. = ..()

--- a/code/modules/mob/living/carbon/werewolf/werewolf_update_icons.dm
+++ b/code/modules/mob/living/carbon/werewolf/werewolf_update_icons.dm
@@ -28,13 +28,13 @@
 		add_overlay(scar_overlay)
 
 	switch(getFireLoss()+getBruteLoss())
-		if(25 to 50)
+		if(50 to 150)
 			var/mutable_appearance/damage_overlay = mutable_appearance(icon, "damage1[laid_down ? "_rest" : ""]")
 			add_overlay(damage_overlay)
-		if(50 to 75)
+		if(150 to 300)
 			var/mutable_appearance/damage_overlay = mutable_appearance(icon, "damage2[laid_down ? "_rest" : ""]")
 			add_overlay(damage_overlay)
-		if(75 to INFINITY)
+		if(300 to INFINITY)
 			var/mutable_appearance/damage_overlay = mutable_appearance(icon, "damage3[laid_down ? "_rest" : ""]")
 			add_overlay(damage_overlay)
 

--- a/code/modules/vtmb/disciplines.dm
+++ b/code/modules/vtmb/disciplines.dm
@@ -183,7 +183,7 @@
 	desc = "Summons Spectral Animals over your targets. Violates Masquerade."
 	icon_state = "animalism"
 	cost = 1
-	delay = 5 SECONDS
+	delay = 8 SECONDS
 	ranged = FALSE
 	violates_masquerade = TRUE
 	activate_sound = 'code/modules/wod13/sounds/wolves.ogg'
@@ -328,7 +328,7 @@
 	icon_state = "celerity"
 	cost = 1
 	ranged = FALSE
-	delay = 50
+	delay = 75
 	violates_masquerade = FALSE
 	activate_sound = 'code/modules/wod13/sounds/celerity_activate.ogg'
 	leveldelay = TRUE
@@ -687,7 +687,7 @@
 	icon_state = "fortitude"
 	cost = 1
 	ranged = FALSE
-	delay = 100
+	delay = 75
 	activate_sound = 'code/modules/wod13/sounds/fortitude_activate.ogg'
 
 /datum/discipline/fortitude/activate(mob/living/target, mob/living/carbon/human/caster)
@@ -959,8 +959,8 @@
 			spawn(delay+caster.discipline_time_plus)
 				if(caster && caster.stat != DEAD)
 					GA.Restore(GA.myshape)
-					caster.Stun(15)
-					caster.do_jitter_animation(30)
+					caster.Stun(10)
+					caster.do_jitter_animation(15)
 //					if(caster.dna)
 					caster.playsound_local(caster, 'code/modules/wod13/sounds/protean_deactivate.ogg', 50, FALSE)
 //						caster.dna.species.attack_verb = initial(caster.dna.species.attack_verb)

--- a/code/modules/vtmb/jobs.dm
+++ b/code/modules/vtmb/jobs.dm
@@ -374,7 +374,7 @@
 
 	liver_traits = list(TRAIT_MEDICAL_METABOLISM)
 
-	allowed_species = list("Vampire", "Ghoul", "Human")
+	allowed_species = list("Vampire", "Ghoul", "Human", "Werewolf")
 	display_order = JOB_DISPLAY_ORDER_DOCTOR
 	bounty_types = CIV_JOB_MED
 
@@ -836,7 +836,7 @@
 
 	paycheck_department = ACCOUNT_CIV
 	display_order = JOB_DISPLAY_ORDER_STRIP
-	allowed_species = list("Vampire", "Ghoul", "Human")
+	allowed_species = list("Vampire", "Ghoul", "Human", "Werewolf")
 
 	v_duty = "Offer strip club services to humans or undead."
 	duty = "Offer strip club services."
@@ -2033,7 +2033,7 @@
 	display_order = JOB_DISPLAY_ORDER_POLICE
 	exp_type_department = EXP_TYPE_INDEPENDENT
 
-	allowed_species = list("Human")
+	allowed_species = list("Human", "Werewolf")
 	minimal_generation = 13
 
 	duty = "Make money, do drugs, fight law. Your hideout is the laundromat in Chinatown."

--- a/code/modules/vtmb/vampire_clane/tzimisce.dm
+++ b/code/modules/vtmb/vampire_clane/tzimisce.dm
@@ -724,22 +724,25 @@
 	minbodytemp = 0
 	bloodpool = 10
 	maxbloodpool = 10
+	dextrous = TRUE
+	held_items = list(null, null)
+	possible_a_intents = list(INTENT_HELP, INTENT_GRAB, INTENT_DISARM, INTENT_HARM)
 
 /mob/living/simple_animal/hostile/gangrel/better
 	maxHealth = 500
 	health = 500
-	melee_damage_lower = 50
-	melee_damage_upper = 50
-	speed = -1
+	melee_damage_lower = 45
+	melee_damage_upper = 45
+	speed = -1.1
 
 /mob/living/simple_animal/hostile/gangrel/best
 	icon_state = "gangrel_m"
 	icon_living = "gangrel_m"
-	maxHealth = 500
-	health = 500
-	melee_damage_lower = 60
-	melee_damage_upper = 60
-	speed = -1
+	maxHealth = 600
+	health = 600
+	melee_damage_lower = 55
+	melee_damage_upper = 55
+	speed = -1.25
 
 /mob/living/simple_animal/hostile/gargoyle
 	name = "Gargoyle"
@@ -754,8 +757,8 @@
 	health = 300
 	butcher_results = list(/obj/item/stack/human_flesh = 20)
 	harm_intent_damage = 5
-	melee_damage_lower = 15
-	melee_damage_upper = 15
+	melee_damage_lower = 30
+	melee_damage_upper = 30
 	attack_verb_continuous = "punches"
 	attack_verb_simple = "punch"
 	attack_sound = 'sound/weapons/punch1.ogg'

--- a/code/modules/wod13/npcroles.dm
+++ b/code/modules/wod13/npcroles.dm
@@ -835,8 +835,8 @@
 	anchored = FALSE
 	footstep_type = FOOTSTEP_MOB_CLAW
 	bloodquality = BLOOD_QUALITY_LOW
-	bloodpool = 1
-	maxbloodpool = 1
+	bloodpool = 2
+	maxbloodpool = 2
 	del_on_death = 1
 	maxHealth = 5
 	health = 5
@@ -912,7 +912,7 @@
 	if(ishuman(A))
 		var/mob/living/carbon/human/H = A
 		if(H.bloodpool)
-			if(prob(5))
+			if(prob(25))
 				H.bloodpool = max(0, H.bloodpool-1)
 				beastmaster.bloodpool = min(beastmaster.maxbloodpool, beastmaster.bloodpool+1)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Attempts a general pass on wolves after many a complaint of them being too flimsy.
+ Gives crinos form more HP and slightly better rage heal
+ Same treatment for lupus
+ Multiple attempts at giving differing speed to both forms (NOT WORKING YET)

Also looks at some other misc values
+ Rat sucker elders don't have to eat 28 rats to sate their hunger, animalism rats not included. (should really be more downsides to ratsucking socially/healthwise later on)
+ Tweaks gangrel warform numbers
+ Gives animalism bats back their niche at a bit better rate.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Garou weren't in a great spot.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: the values because that is all I can do as a shitcoder
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
