### PR TITLE
Your Big Fat Garou veil recovery hotfix

### DIFF
--- a/code/modules/mob/living/carbon/werewolf/life.dm
+++ b/code/modules/mob/living/carbon/werewolf/life.dm
@@ -66,26 +66,26 @@
 
 			if(istype(get_area(src), /area/vtm/interior/penumbra))
 				if(last_veil_restore+400 < world.time)
-					adjust_veil(1)
+					adjust_veil(1, src, TRUE)
 					last_veil_restore = world.time
 
 			switch(src.auspice.tribe)
 				if("Wendigo")
 					if(istype(get_area(src), /area/vtm/forest))
-						if(last_veil_restore+600 <= world.time)
-							adjust_veil(1)
+						if(last_veil_restore+500 <= world.time)
+							adjust_veil(1, src, TRUE)
 							last_veil_restore = world.time
 
 				if("Glasswalkers")
 					if(istype(get_area(src), /area/vtm/interior/glasswalker))
-						if(last_veil_restore+600 <= world.time)
-							adjust_veil(1) // These three instances of adjust_veil don't add to masq points?
-							last_veil_restore = world.time		
+						if(last_veil_restore+500 <= world.time)
+							adjust_veil(1, src, TRUE)
+							last_veil_restore = world.time
 
 /mob/living/carbon/werewolf/crinos/Life()
 	. = ..()
 	if(CheckEyewitness(src, src, 5, FALSE))
-		adjust_veil(-1) // BUT THIS WORKS AND REMOVES MASQ POINTS, WHY??
+		adjust_veil(-1)
 
 /mob/living/carbon/werewolf/check_breath(datum/gas_mixture/breath)
 	return
@@ -106,14 +106,14 @@
 	adjust_bodytemperature(BODYTEMP_HEATING_MAX) //If you're on fire, you heat up!
 
 /mob/living/carbon/proc/adjust_veil(var/amount)
-	//if(!GLOB.canon_event)
-	//	return
-	if(last_veil_adjusting+100 >= world.time)  //time on this very low for testing, needs correcting later
+	if(!GLOB.canon_event)
+		return
+	if(last_veil_adjusting+200 >= world.time)
 		return
 	if(amount > 0)
 		if(HAS_TRAIT(src, TRAIT_VIOLATOR))
 			return
-	if(amount < 0)	
+	if(amount < 0)
 		if(istype(get_area(src), /area/vtm))
 			var/area/vtm/V = get_area(src)
 			if(V.zone_type != "masquerade")
@@ -130,10 +130,8 @@
 				SEND_SOUND(src, sound('code/modules/wod13/sounds/veil_violation.ogg', 0, 0, 75))
 				to_chat(src, "<span class='boldnotice'><b>VEIL VIOLATION</b></span>")
 				masquerade = max(0, masquerade+amount)
-				//AdjustMasquerade(-1) couldn't define these properly I'm too stupid. but this should be unnecessary if the adjust_veil would work properly ???
 		if(amount > 0)
 			if(masquerade < 5)
 				SEND_SOUND(src, sound('code/modules/wod13/sounds/humanity_gain.ogg', 0, 0, 75))
 				to_chat(src, "<span class='boldnotice'><b>VEIL REINFORCEMENT</b></span>")
-				masquerade = max(0, masquerade-amount)
-				//AdjustMasquerade(1)
+				masquerade = min(5, masquerade+amount)

--- a/code/modules/mob/living/carbon/werewolf/life.dm
+++ b/code/modules/mob/living/carbon/werewolf/life.dm
@@ -63,15 +63,29 @@
 					if(last_frenzy_check+400 <= world.time)
 						last_frenzy_check = world.time
 						rollfrenzy()
+
 			if(istype(get_area(src), /area/vtm/interior/penumbra))
-				if(last_veil_restore+600 < world.time)
-					last_veil_restore = world.time
+				if(last_veil_restore+400 < world.time)
 					adjust_veil(1)
+					last_veil_restore = world.time
+
+			switch(src.auspice.tribe)
+				if("Wendigo")
+					if(istype(get_area(src), /area/vtm/forest))
+						if(last_veil_restore+600 <= world.time)
+							adjust_veil(1)
+							last_veil_restore = world.time
+
+				if("Glasswalkers")
+					if(istype(get_area(src), /area/vtm/interior/glasswalker))
+						if(last_veil_restore+600 <= world.time)
+							adjust_veil(1) // These three instances of adjust_veil don't add to masq points?
+							last_veil_restore = world.time		
 
 /mob/living/carbon/werewolf/crinos/Life()
 	. = ..()
 	if(CheckEyewitness(src, src, 5, FALSE))
-		adjust_veil(-1)
+		adjust_veil(-1) // BUT THIS WORKS AND REMOVES MASQ POINTS, WHY??
 
 /mob/living/carbon/werewolf/check_breath(datum/gas_mixture/breath)
 	return
@@ -92,17 +106,18 @@
 	adjust_bodytemperature(BODYTEMP_HEATING_MAX) //If you're on fire, you heat up!
 
 /mob/living/carbon/proc/adjust_veil(var/amount)
-	if(!GLOB.canon_event)
-		return
-	if(last_veil_adjusting+100 >= world.time)
+	//if(!GLOB.canon_event)
+	//	return
+	if(last_veil_adjusting+100 >= world.time)  //time on this very low for testing, needs correcting later
 		return
 	if(amount > 0)
 		if(HAS_TRAIT(src, TRAIT_VIOLATOR))
 			return
-	if(istype(get_area(src), /area/vtm))
-		var/area/vtm/V = get_area(src)
-		if(V.zone_type != "masquerade")
-			return
+	if(amount < 0)	
+		if(istype(get_area(src), /area/vtm))
+			var/area/vtm/V = get_area(src)
+			if(V.zone_type != "masquerade")
+				return
 	last_veil_adjusting = world.time
 	var/special_role_name
 	if(mind)
@@ -115,8 +130,10 @@
 				SEND_SOUND(src, sound('code/modules/wod13/sounds/veil_violation.ogg', 0, 0, 75))
 				to_chat(src, "<span class='boldnotice'><b>VEIL VIOLATION</b></span>")
 				masquerade = max(0, masquerade+amount)
+				//AdjustMasquerade(-1) couldn't define these properly I'm too stupid. but this should be unnecessary if the adjust_veil would work properly ???
 		if(amount > 0)
 			if(masquerade < 5)
 				SEND_SOUND(src, sound('code/modules/wod13/sounds/humanity_gain.ogg', 0, 0, 75))
 				to_chat(src, "<span class='boldnotice'><b>VEIL REINFORCEMENT</b></span>")
 				masquerade = max(0, masquerade-amount)
+				//AdjustMasquerade(1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gives garou the ability to fix their veil score progressively by spending time in the penumbra universally or their tribe's varying areas. Currently IT ALL JUST WORKS.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No more wolves breaking global masq by being seen in crinos with no way to fix it.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked myself closer to an aneurysm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
