### PR TITLE
Radio addition and remove dumb Salubri gimmick thing (DO NOT MERGE YET)

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -374,6 +374,27 @@
 	on = TRUE
 	return TRUE
 
+
+/obj/item/radio/cop
+	name = "police radio"
+	subspace_transmission = FALSE
+	subspace_switchable = FALSE
+	keyslot = new /obj/item/encryptionkey/headset_sec
+
+/obj/item/radio/cop/Initialize()
+	. = ..()
+	set_frequency(FREQ_SECURITY)
+
+/obj/item/radio/clinic
+	name = "clinic radio"
+	subspace_transmission = FALSE
+	subspace_switchable = FALSE
+	keyslot = new /obj/item/encryptionkey/headset_medsci
+
+/obj/item/radio/clinic/Initialize()
+	. = ..()
+	set_frequency(FREQ_MEDICAL)
+
 ///////////////////////////////
 //////////Borg Radios//////////
 ///////////////////////////////

--- a/code/modules/vtmb/jobs.dm
+++ b/code/modules/vtmb/jobs.dm
@@ -396,6 +396,7 @@
 	l_hand = /obj/item/storage/firstaid/medical
 	l_pocket = /obj/item/vamp/phone
 	r_pocket = /obj/item/vamp/keys/clinic
+	r_hand = /obj/item/radio/clinic
 	backpack_contents = list(/obj/item/passport=1, /obj/item/cockclock=1, /obj/item/flashlight=1, /obj/item/vamp/creditcard=1)
 
 	backpack = /obj/item/storage/backpack
@@ -1969,7 +1970,7 @@
 	gloves = /obj/item/cockclock
 	id = /obj/item/card/id/police
 	l_pocket = /obj/item/vamp/phone
-	r_pocket = /obj/item/flashlight
+	r_pocket = /obj/item/radio/cop
 	l_hand = /obj/item/vamp/keys/police
 	r_hand = /obj/item/police_radio
 	backpack_contents = list(/obj/item/passport=1, /obj/item/implant/radio=1, /obj/item/vamp/creditcard=1, /obj/item/gun/ballistic/vampire/revolver/snub=1, /obj/item/ammo_box/vampire/c9mm/moonclip = 2, /obj/item/ammo_box/vampire/c9mm = 1, /obj/item/restraints/handcuffs = 1)
@@ -2012,7 +2013,7 @@
 	id = /obj/item/card/id/police
 	gloves = /obj/item/cockclock
 	l_pocket = /obj/item/vamp/phone
-	r_pocket = /obj/item/flashlight
+	r_pocket = /obj/item/radio/cop
 	l_hand = /obj/item/vamp/keys/police
 	r_hand = /obj/item/police_radio
 	backpack_contents = list(/obj/item/passport=1, /obj/item/implant/radio=1, /obj/item/gun/ballistic/automatic/vampire/m1911=1, /obj/item/camera/detective=1, /obj/item/camera_film=1, /obj/item/taperecorder=1, /obj/item/tape=1, /obj/item/vamp/creditcard=1)

--- a/code/modules/vtmb/vampire_clane/salubri.dm
+++ b/code/modules/vtmb/vampire_clane/salubri.dm
@@ -1,7 +1,7 @@
 /datum/vampireclane/salubri
 	name = "Salubri"
-	desc = "The Salubri are one of the original 13 clans of the vampiric descendants of Caine. Salubri believe that vampiric existence is torment from which Golconda or death is the only escape. Consequently, the modern Salubri would Embrace, teach a childe the basics of the route, leave clues for the childe to follow to achieve Golconda, and then have their childe diablerize them."
-	curse = "Hunted and only con feeding."
+	desc = "The Salubri are one of the original 13 clans of the vampiric descendants of Caine. Salubri believe that vampiric existence is torment from which Golconda or death is the only escape. Consequently, the modern Salubri would Embrace, teach a childe the basics of the route, leave clues for the childe to follow to achieve Golconda, and then have their childe diablerize them..Morallity is key"
+	curse = "Hunted or Asceticism(Consentual feeding)."
 	clane_disciplines = list(
 		/datum/discipline/auspex = 1,
 		/datum/discipline/fortitude = 2,

--- a/code/modules/wod13/bloodsucking.dm
+++ b/code/modules/wod13/bloodsucking.dm
@@ -62,18 +62,12 @@
 						var/datum/antagonist/A = mind.special_role
 						special_role_name = A.name
 				if(clane)
-					var/salubri_allowed = FALSE
-					var/mob/living/carbon/human/H = mob
-					if(H.clane)
-						if(H.clane.name == "Salubri")
-							salubri_allowed = TRUE
 					if(clane.name != "Banu Haqim" && clane.name != "Caitiff")
-						if(!salubri_allowed)
-							if(!mind.special_role || special_role_name == "Ambitious")
-								to_chat(src, "<span class='warning'>You find the idea of drinking your own <b>KIND's</b> blood disgusting!</span>")
-								last_drinkblood_use = 0
-								if(client)
-									client.images -= suckbar
+						if(!mind.special_role || special_role_name == "Ambitious")
+							to_chat(src, "<span class='warning'>You find the idea of drinking your own <b>KIND's</b> blood disgusting!</span>")
+							last_drinkblood_use = 0
+							if(client)
+								client.images -= suckbar
 								qdel(suckbar)
 								stop_sound_channel(CHANNEL_BLOOD)
 								return

--- a/code/modules/wod13/witness.dm
+++ b/code/modules/wod13/witness.dm
@@ -1,5 +1,5 @@
 /obj/item/police_radio
-	name = "police frequence radio"
+	name = "dispatch frequency radio"
 	desc = "911, I'm stuck in my dishwasher and stepbrother is coming in my room..."
 	icon_state = "radio"
 	icon = 'code/modules/wod13/items.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removed the content that prevented Salubri from drinking kine blood from the bloodsucking.dm , altered the text for curse description for Salubri to be "Hunted and Asceticism(Consentual feeding)"

renamed the old pd radio to be a dispatch radio, PD/Clinical roles now spawn with an actual walkie talkie.

## Why It's Good For The Game
It'll assist Police and Clinical players in keeping in contact and makes more sense then everyone relying on phones 24/7 for buisness.

Salubri being unable to roleplay getting consent to drink from a kine was dumb so I removed it, and described it more in their desc.

## Changelog
:cl:
add: PD/Clinic radios
del: remove code keeping Salubri from drinking kine blood
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
