### PR TITLE
Creates a Hospital Vendor & Adds Surgical Kits

### DIFF
--- a/code/modules/wod13/food.dm
+++ b/code/modules/wod13/food.dm
@@ -479,6 +479,7 @@
 		new /datum/data/mining_equipment("stake",	/obj/item/vampire_stake,	100),
 		new /datum/data/mining_equipment("lockpick",	/obj/item/vamp/keys/hack, 50),
 		new /datum/data/mining_equipment("zippo lighter",	/obj/item/lighter,	20),
+		new /datum/data/mining_equipment("Surgery dufflebag", /obj/item/storage/backpack/duffelbag/med/surgery, 100),
 		new /datum/data/mining_equipment("lighter",		/obj/item/lighter/greyscale,	10)
 		)
 
@@ -488,6 +489,23 @@
 		new /datum/data/mining_equipment("iron pill bottle", /obj/item/storage/pill_bottle/iron, 150),
 		new /datum/data/mining_equipment("potassium iodide pill bottle", /obj/item/storage/pill_bottle/potassiodide, 100),
 		new /datum/data/mining_equipment("bruise pack", /obj/item/stack/medical/bruise_pack, 100),
+		new /datum/data/mining_equipment("burn ointment", /obj/item/stack/medical/ointment, 100)
+		)
+
+/obj/machinery/mineral/equipment_vendor/fastfood/hospital // we should probably swap from a vendor system and work on a sort of gameplay loop - tzula
+	prize_list = list(
+		new /datum/data/mining_equipment("toxins first aid kit", /obj/item/storage/firstaid/toxin, 50),
+		new /datum/data/mining_equipment("burns first aid kit", /obj/item/storage/firstaid/fire, 50),
+		new /datum/data/mining_equipment("standard first aid kit", /obj/item/storage/firstaid/medical, 50),
+		new /datum/data/mining_equipment("respiratory aid kit", /obj/item/storage/firstaid/o2, 50),
+		new /datum/data/mining_equipment("potassium iodide pill bottle", /obj/item/defibrillator/compact, 100),
+		new /datum/data/mining_equipment("defib batteries", /obj/item/stock_parts/cell, 50),
+		new /datum/data/mining_equipment("surgery dufflebag", /obj/item/storage/backpack/duffelbag/med/surgery, 100),
+		new /datum/data/mining_equipment("ephedrine pill bottle", /obj/item/storage/pill_bottle/ephedrine, 200),
+		new /datum/data/mining_equipment("iron pill bottle", /obj/item/storage/pill_bottle/iron, 150),
+		new /datum/data/mining_equipment("bruise pack", /obj/item/stack/medical/bruise_pack, 100),
+		new /datum/data/mining_equipment("surgical apron", /obj/item/clothing/suit/apron/surgical, 100),
+		new /datum/data/mining_equipment("latex gloves", /obj/item/clothing/gloves/vampire/latex, 100),
 		new /datum/data/mining_equipment("burn ointment", /obj/item/stack/medical/ointment, 100)
 		)
 


### PR DESCRIPTION
## About The Pull Request

The following PR allows hospital staff to get a vendor that allows them to restock on goods for the time being as we figure out a gameplay loop. This PR also lets people start to set up their makeshift clinics too to facilitate gimmicks. The vendor needs to be added next map update cycle.

## Why It's Good For The Game

As mentioned above, this allows people to set up their gimmick area if they wanted to be a quirky doctor. Hospital players also asked for this to be added in too.

## Changelog
:cl:
Adds a vendor for the hospital!
Gives the blackmarket dealer a surgical bag.
/:cl:
