### PR TITLE
Bunch of Fixes and QOL

### DIFF
--- a/code/__DEFINES/wod13.dm
+++ b/code/__DEFINES/wod13.dm
@@ -1,0 +1,3 @@
+#define ROLL_BOTCH -1
+#define ROLL_FAILURE 0
+#define ROLL_SUCCESS 1

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -120,4 +120,4 @@
 
 	var/soul_state = SOUL_PRESENT
 
-//	var/atom/movable/screen/disciplines/toggled
+	var/can_be_embraced = TRUE

--- a/code/modules/vtmb/disciplines.dm
+++ b/code/modules/vtmb/disciplines.dm
@@ -1813,21 +1813,24 @@
 			if(new_say)
 				target.say("[new_say]", forced = "melpominee 2")
 
+				var/base_difficulty = 6
 				var/difficulty_malus = 0
 				var/masked = FALSE
-				if (ishuman(target)) //apply a malus and different text if victim's mouth isn't visible
+				if (ishuman(target)) //apply a malus and different text if victim's mouth isn't visible, and a malus if they're already typing
 					var/mob/living/carbon/human/victim = target
 					if ((victim.wear_mask?.flags_inv & HIDEFACE) || (victim.head?.flags_inv & HIDEFACE))
 						masked = TRUE
+						base_difficulty += 2
+					if (victim.overlays_standing[SAY_LAYER]) //ugly way to check for if the victim is currently typing
+						base_difficulty += 1
+
 				for (var/mob/living/hearer in (view(7, target) - caster - target))
 					if (!hearer.client)
 						continue
 					difficulty_malus = 0
-					if (masked)
-						difficulty_malus += 2
 					if (get_dist(hearer, target) > 3)
 						difficulty_malus += 1
-					if (storyteller_roll(hearer.mentality + hearer.additional_mentality, 6 + difficulty_malus) == ROLL_SUCCESS)
+					if (storyteller_roll(hearer.mentality + hearer.additional_mentality, base_difficulty + difficulty_malus) == ROLL_SUCCESS)
 						if (masked)
 							to_chat(hearer, "<span class='warning'>[target.name]'s jaw isn't moving to match [target.p_their()] words.</span>")
 						else

--- a/code/modules/vtmb/disciplines.dm
+++ b/code/modules/vtmb/disciplines.dm
@@ -1813,7 +1813,7 @@
 			if(new_say)
 				target.say("[new_say]", forced = "melpominee 2")
 
-				var/base_difficulty = 6
+				var/base_difficulty = 5
 				var/difficulty_malus = 0
 				var/masked = FALSE
 				if (ishuman(target)) //apply a malus and different text if victim's mouth isn't visible, and a malus if they're already typing

--- a/code/modules/vtmb/disciplines.dm
+++ b/code/modules/vtmb/disciplines.dm
@@ -1815,29 +1815,44 @@
 		if(2)
 			var/new_say = input(caster, "What will your target say?") as text|null
 			if(new_say)
-				target.say("[new_say]")
+				target.say("[new_say]", forced = "melpominee 2")
+
+				if (ishuman(target))
+					var/mob/living/carbon/human/victim = target
+					if ((victim.wear_mask?.flags_inv & HIDEFACE) || (victim.head?.flags_inv & HIDEFACE))
+						for (var/mob/living/carbon/hearer in (view(7, target) - caster - target))
+							if (!hearer.client?.prefs)
+								continue
+							if (storyteller_roll(hearer.mentality + hearer.additional_mentality, 8) == ROLL_SUCCESS)
+								to_chat(hearer, "<span class='warning'>[victim.name]'s jaw isn't moving to match [victim.p_their()] words.</span>")
+						return
+				for (var/mob/living/carbon/hearer in (view(7, target) - caster - target))
+					if (!hearer.client?.prefs)
+						continue
+					if (storyteller_roll(hearer.mentality + hearer.additional_mentality, 6) == ROLL_SUCCESS)
+						to_chat(hearer, "<span class='warning'>[target.name]'s lips aren't moving to match [target.p_their()] words.</span>")
 		if(3)
 			for(var/mob/living/carbon/human/HU in oviewers(7, caster))
 				if(HU)
 					HU.caster = caster
-					HU.create_walk_to(20)
+					HU.create_walk_to(2 SECONDS)
 					HU.remove_overlay(MUTATIONS_LAYER)
 					var/mutable_appearance/song_overlay = mutable_appearance('code/modules/wod13/icons.dmi', "song", -MUTATIONS_LAYER)
 					HU.overlays_standing[MUTATIONS_LAYER] = song_overlay
 					HU.apply_overlay(MUTATIONS_LAYER)
-					spawn(20)
+					spawn(2 SECONDS)
 						if(HU)
 							HU.remove_overlay(MUTATIONS_LAYER)
 		if(4)
 			playsound(caster.loc, 'code/modules/wod13/sounds/killscream.ogg', 100, FALSE)
 			for(var/mob/living/carbon/human/HU in oviewers(7, caster))
 				if(HU)
-					HU.Stun(20)
+					HU.Stun(2 SECONDS)
 					HU.remove_overlay(MUTATIONS_LAYER)
 					var/mutable_appearance/song_overlay = mutable_appearance('code/modules/wod13/icons.dmi', "song", -MUTATIONS_LAYER)
 					HU.overlays_standing[MUTATIONS_LAYER] = song_overlay
 					HU.apply_overlay(MUTATIONS_LAYER)
-					spawn(20)
+					spawn(2 SECONDS)
 						if(HU)
 							HU.remove_overlay(MUTATIONS_LAYER)
 		if(5)

--- a/code/modules/vtmb/disciplines.dm
+++ b/code/modules/vtmb/disciplines.dm
@@ -1822,7 +1822,7 @@
 						masked = TRUE
 						base_difficulty += 2
 					if (victim.overlays_standing[SAY_LAYER]) //ugly way to check for if the victim is currently typing
-						base_difficulty += 1
+						base_difficulty += 2
 
 				for (var/mob/living/hearer in (view(7, target) - caster - target))
 					if (!hearer.client)

--- a/code/modules/vtmb/disciplines.dm
+++ b/code/modules/vtmb/disciplines.dm
@@ -1813,25 +1813,25 @@
 			if(new_say)
 				target.say("[new_say]", forced = "melpominee 2")
 
-				var/difficulty_bonus = 0
-				if (ishuman(target))
+				var/difficulty_malus = 0
+				var/masked = FALSE
+				if (ishuman(target)) //apply a malus and different text if victim's mouth isn't visible
 					var/mob/living/carbon/human/victim = target
 					if ((victim.wear_mask?.flags_inv & HIDEFACE) || (victim.head?.flags_inv & HIDEFACE))
-						for (var/mob/living/carbon/hearer in (view(7, target) - caster - target))
-							if (!hearer.client?.prefs)
-								continue
-							if (get_dist(hearer, target) > 3)
-								difficulty_bonus++
-							if (storyteller_roll(hearer.mentality + hearer.additional_mentality, 8 + difficulty_bonus) == ROLL_SUCCESS)
-								to_chat(hearer, "<span class='warning'>[victim.name]'s jaw isn't moving to match [victim.p_their()] words.</span>")
-						return
-				for (var/mob/living/carbon/hearer in (view(7, target) - caster - target))
-					if (!hearer.client?.prefs)
+						masked = TRUE
+				for (var/mob/living/hearer in (view(7, target) - caster - target))
+					if (!hearer.client)
 						continue
+					difficulty_malus = 0
+					if (masked)
+						difficulty_malus += 2
 					if (get_dist(hearer, target) > 3)
-						difficulty_bonus++
-					if (storyteller_roll(hearer.mentality + hearer.additional_mentality, 6 + difficulty_bonus) == ROLL_SUCCESS)
-						to_chat(hearer, "<span class='warning'>[target.name]'s lips aren't moving to match [target.p_their()] words.</span>")
+						difficulty_malus += 1
+					if (storyteller_roll(hearer.mentality + hearer.additional_mentality, 6 + difficulty_malus) == ROLL_SUCCESS)
+						if (masked)
+							to_chat(hearer, "<span class='warning'>[target.name]'s jaw isn't moving to match [target.p_their()] words.</span>")
+						else
+							to_chat(hearer, "<span class='warning'>[target.name]'s lips aren't moving to match [target.p_their()] words.</span>")
 		if(3)
 			for(var/mob/living/carbon/human/HU in oviewers(7, caster))
 				if(HU)

--- a/code/modules/vtmb/disciplines.dm
+++ b/code/modules/vtmb/disciplines.dm
@@ -1813,19 +1813,24 @@
 			if(new_say)
 				target.say("[new_say]", forced = "melpominee 2")
 
+				var/difficulty_bonus = 0
 				if (ishuman(target))
 					var/mob/living/carbon/human/victim = target
 					if ((victim.wear_mask?.flags_inv & HIDEFACE) || (victim.head?.flags_inv & HIDEFACE))
 						for (var/mob/living/carbon/hearer in (view(7, target) - caster - target))
 							if (!hearer.client?.prefs)
 								continue
-							if (storyteller_roll(hearer.mentality + hearer.additional_mentality, 8) == ROLL_SUCCESS)
+							if (get_dist(hearer, target) >= 4)
+								difficulty_bonus++
+							if (storyteller_roll(hearer.mentality + hearer.additional_mentality, 8 + difficulty_bonus) == ROLL_SUCCESS)
 								to_chat(hearer, "<span class='warning'>[victim.name]'s jaw isn't moving to match [victim.p_their()] words.</span>")
 						return
 				for (var/mob/living/carbon/hearer in (view(7, target) - caster - target))
 					if (!hearer.client?.prefs)
 						continue
-					if (storyteller_roll(hearer.mentality + hearer.additional_mentality, 6) == ROLL_SUCCESS)
+					if (get_dist(hearer, target) >= 4)
+						difficulty_bonus++
+					if (storyteller_roll(hearer.mentality + hearer.additional_mentality, 6 + difficulty_bonus) == ROLL_SUCCESS)
 						to_chat(hearer, "<span class='warning'>[target.name]'s lips aren't moving to match [target.p_their()] words.</span>")
 		if(3)
 			for(var/mob/living/carbon/human/HU in oviewers(7, caster))

--- a/code/modules/vtmb/disciplines.dm
+++ b/code/modules/vtmb/disciplines.dm
@@ -284,12 +284,8 @@
 		next_fire_after = world.time+delay*level_casting
 	else
 		next_fire_after = world.time+delay
-//	if(!target)
-//		var/choice = input(caster, "Choose your target", "Available Targets") as mob in oviewers(4, caster)
-//		if(choice)
-//			target = choice
-//		else
-//			return
+
+	log_attack("[key_name(caster)] casted level [src.level_casting] of the Discipline [src.name][target == caster ? "." : " on [key_name(target)]"]")
 
 /datum/discipline/animalism
 	name = "Animalism"

--- a/code/modules/vtmb/disciplines.dm
+++ b/code/modules/vtmb/disciplines.dm
@@ -1820,7 +1820,7 @@
 						for (var/mob/living/carbon/hearer in (view(7, target) - caster - target))
 							if (!hearer.client?.prefs)
 								continue
-							if (get_dist(hearer, target) >= 4)
+							if (get_dist(hearer, target) > 3)
 								difficulty_bonus++
 							if (storyteller_roll(hearer.mentality + hearer.additional_mentality, 8 + difficulty_bonus) == ROLL_SUCCESS)
 								to_chat(hearer, "<span class='warning'>[victim.name]'s jaw isn't moving to match [victim.p_their()] words.</span>")
@@ -1828,7 +1828,7 @@
 				for (var/mob/living/carbon/hearer in (view(7, target) - caster - target))
 					if (!hearer.client?.prefs)
 						continue
-					if (get_dist(hearer, target) >= 4)
+					if (get_dist(hearer, target) > 3)
 						difficulty_bonus++
 					if (storyteller_roll(hearer.mentality + hearer.additional_mentality, 6 + difficulty_bonus) == ROLL_SUCCESS)
 						to_chat(hearer, "<span class='warning'>[target.name]'s lips aren't moving to match [target.p_their()] words.</span>")

--- a/code/modules/vtmb/frenzy.dm
+++ b/code/modules/vtmb/frenzy.dm
@@ -281,7 +281,7 @@
 			GLOB.masquerade_breakers_list -= H
 */
 
-	if(H.key && H.stat <= 3)
+	if(H.key && H.stat <= HARD_CRIT)
 		var/datum/preferences/P = GLOB.preferences_datums[ckey(H.key)]
 		if(P)
 			if(P.humanity != H.humanity)
@@ -292,27 +292,10 @@
 				P.masquerade = H.masquerade
 				P.save_preferences()
 				P.save_character()
-//			if(H.last_experience+600 <= world.time)
-//				var/addd = 5
-//				if(!H.JOB && H.mind)
-//					H.JOB = SSjob.GetJob(H.mind.assigned_role)
-//					if(H.JOB)
-//						addd = H.JOB.experience_addition
-//				P.exper = min(calculate_mob_max_exper(H), P.exper+addd+H.experience_plus)
-//				if(P.exper == calculate_mob_max_exper(H))
-//					to_chat(H, "You've reached a new level! You can add new points in Character Setup (Lobby screen).")
-//				P.save_preferences()
-//				P.save_character()
-//				H.last_experience = world.time
-//			if(H.roundstart_vampire)
-//				if(P.generation != H.generation)
-//					P.generation = H.generation
-//					P.save_preferences()
-//					P.save_character()
 			if(!H.antifrenzy)
 				if(P.humanity < 1)
 					H.enter_frenzymod()
-//					reset_shit(H)
+					to_chat(H, "<span class='userdanger'>You have lost control of the Beast within you, and it has taken your body. Be more [H.client.prefs.enlightement ? "Enlightened" : "humane"] next time.</span>")
 					H.ghostize(FALSE)
 					P.reason_of_death = "Lost control to the Beast ([time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")])."
 

--- a/code/modules/vtmb/kindred_species.dm
+++ b/code/modules/vtmb/kindred_species.dm
@@ -328,22 +328,28 @@
 
 					if((BLOODBONDED.respawntimeofdeath + 5 MINUTES) > world.time)
 						if (BLOODBONDED.auspice?.level) //here be Abominations
-							switch(storyteller_roll(BLOODBONDED.auspice.level))
-								if (ROLL_BOTCH)
-									to_chat(H, "<span class='danger'>Something terrible is happening.</span>")
-									to_chat(BLOODBONDED, "<span class='userdanger'>Gaia has forsaken you.</span>")
-									message_admins("[ADMIN_LOOKUPFLW(H)] has turned [ADMIN_LOOKUPFLW(BLOODBONDED)] into an Abomination.")
-									log_game("[key_name(H)] has turned [key_name(BLOODBONDED)] into an Abomination.")
-								if (ROLL_FAILURE)
-									BLOODBONDED.visible_message("<span class='warning'>[BLOODBONDED.name] convulses in sheer agony!</span>")
-									BLOODBONDED.Shake(15, 15, 5 SECONDS)
-									playsound(BLOODBONDED.loc, 'code/modules/wod13/sounds/vicissitude.ogg', 100, TRUE)
-									BLOODBONDED.can_be_embraced = FALSE
-									return
-								if (ROLL_SUCCESS)
-									to_chat(H, "<span class='notice'>[BLOODBONDED.name] does not respond to your Vitae...</span>")
-									BLOODBONDED.can_be_embraced = FALSE
-									return
+							if (BLOODBONDED.auspice.force_abomination)
+								to_chat(H, "<span class='danger'>Something terrible is happening.</span>")
+								to_chat(BLOODBONDED, "<span class='userdanger'>Gaia has forsaken you.</span>")
+								message_admins("[ADMIN_LOOKUPFLW(H)] has turned [ADMIN_LOOKUPFLW(BLOODBONDED)] into an Abomination through an admin setting the force_abomination var.")
+								log_game("[key_name(H)] has turned [key_name(BLOODBONDED)] into an Abomination through an admin setting the force_abomination var.")
+							else
+								switch(storyteller_roll(BLOODBONDED.auspice.level))
+									if (ROLL_BOTCH)
+										to_chat(H, "<span class='danger'>Something terrible is happening.</span>")
+										to_chat(BLOODBONDED, "<span class='userdanger'>Gaia has forsaken you.</span>")
+										message_admins("[ADMIN_LOOKUPFLW(H)] has turned [ADMIN_LOOKUPFLW(BLOODBONDED)] into an Abomination.")
+										log_game("[key_name(H)] has turned [key_name(BLOODBONDED)] into an Abomination.")
+									if (ROLL_FAILURE)
+										BLOODBONDED.visible_message("<span class='warning'>[BLOODBONDED.name] convulses in sheer agony!</span>")
+										BLOODBONDED.Shake(15, 15, 5 SECONDS)
+										playsound(BLOODBONDED.loc, 'code/modules/wod13/sounds/vicissitude.ogg', 100, TRUE)
+										BLOODBONDED.can_be_embraced = FALSE
+										return
+									if (ROLL_SUCCESS)
+										to_chat(H, "<span class='notice'>[BLOODBONDED.name] does not respond to your Vitae...</span>")
+										BLOODBONDED.can_be_embraced = FALSE
+										return
 
 						log_game("[key_name(H)] has Embraced [key_name(BLOODBONDED)].")
 						message_admins("[ADMIN_VERBOSEJMP(H)] has Embraced [ADMIN_VERBOSEJMP(BLOODBONDED)].")

--- a/code/modules/vtmb/kindred_species.dm
+++ b/code/modules/vtmb/kindred_species.dm
@@ -299,14 +299,16 @@
 				if(!BLOODBONDED.key)
 					to_chat(owner, "<span class='warning'>You need [BLOODBONDED]'s mind to Embrace!</span>")
 					return
-				message_admins("[H]([H.key]) is embracing [BLOODBONDED]([BLOODBONDED.key])!")
+				message_admins("[ADMIN_LOOKUPFLW(H)] is Embracing [ADMIN_LOOKUPFLW(BLOODBONDED)]!")
 			if(giving)
 				return
 			giving = TRUE
 			owner.visible_message("<span class='warning'>[owner] tries to feed [BLOODBONDED] with their own blood!</span>", "<span class='notice'>You started to feed [BLOODBONDED] with your own blood.</span>")
 			if(do_mob(owner, BLOODBONDED, 10 SECONDS))
-				var/new_master = FALSE
+				H.bloodpool = max(0, H.bloodpool-2)
 				giving = FALSE
+
+				var/new_master = FALSE
 				BLOODBONDED.faction |= H.faction
 				if(!istype(BLOODBONDED, /mob/living/carbon/human/npc))
 					if(H.vampire_faction == "Camarilla" || H.vampire_faction == "Anarch" || H.vampire_faction == "Sabbat")
@@ -320,7 +322,31 @@
 							to_chat(BLOODBONDED, "<span class='notice'>You are now member of <b>[H.vampire_faction]</b></span>")
 				BLOODBONDED.drunked_of |= "[H.dna.real_name]"
 				if(BLOODBONDED.stat == DEAD && !iskindred(BLOODBONDED))
-					if(BLOODBONDED.respawntimeofdeath+6000 > world.time)
+					if (!BLOODBONDED.can_be_embraced)
+						to_chat(H, "<span class='notice'>[BLOODBONDED.name] doesn't respond to your Vitae.</span>")
+						return
+
+					if((BLOODBONDED.respawntimeofdeath + 5 MINUTES) > world.time)
+						if (BLOODBONDED.auspice?.level) //here be Abominations
+							switch(storyteller_roll(BLOODBONDED.auspice.level))
+								if (ROLL_BOTCH)
+									to_chat(H, "<span class='danger'>Something terrible is happening.</span>")
+									to_chat(BLOODBONDED, "<span class='userdanger'>Gaia has forsaken you.</span>")
+									message_admins("[ADMIN_LOOKUPFLW(H)] has turned [ADMIN_LOOKUPFLW(BLOODBONDED)] into an Abomination.")
+									log_game("[key_name(H)] has turned [key_name(BLOODBONDED)] into an Abomination.")
+								if (ROLL_FAILURE)
+									BLOODBONDED.visible_message("<span class='warning'>[BLOODBONDED.name] convulses in sheer agony!</span>")
+									BLOODBONDED.Shake(15, 15, 5 SECONDS)
+									playsound(BLOODBONDED.loc, 'code/modules/wod13/sounds/vicissitude.ogg', 100, TRUE)
+									BLOODBONDED.can_be_embraced = FALSE
+									return
+								if (ROLL_SUCCESS)
+									to_chat(H, "<span class='notice'>[BLOODBONDED.name] does not respond to your Vitae...</span>")
+									BLOODBONDED.can_be_embraced = FALSE
+									return
+
+						log_game("[key_name(H)] has Embraced [key_name(BLOODBONDED)].")
+						message_admins("[ADMIN_VERBOSEJMP(H)] has Embraced [ADMIN_VERBOSEJMP(BLOODBONDED)].")
 						giving = FALSE
 						if(BLOODBONDED.revive(full_heal = TRUE, admin_revive = TRUE))
 							BLOODBONDED.grab_ghost(force = TRUE)
@@ -344,12 +370,6 @@
 								BLOODBONDED.health = round((initial(BLOODBONDED.maxHealth)-initial(BLOODBONDED.maxHealth)/4)+(initial(BLOODBONDED.maxHealth)/4)*(BLOODBONDED.physique+13-BLOODBONDED.generation))
 						else
 							BLOODBONDED.clane = new /datum/vampireclane/caitiff()
-//						BLOODBONDED.hud_used.drinkblood_icon.icon_state = "drink"
-//						BLOODBONDED.hud_used.healths.icon = 'code/modules/wod13/32x48.dmi'
-//						qdel(BLOODBONDED.hud_used)
-//						BLOODBONDED.hud_used = new BLOODBONDED.hud_type(BLOODBONDED)
-//						BLOODBONDED.update_sight()
-//						SEND_SIGNAL(BLOODBONDED, COMSIG_MOB_HUD_CREATED)
 					else
 						to_chat(owner, "<span class='notice'>[BLOODBONDED] is totally <b>DEAD</b>!</span>")
 						giving = FALSE
@@ -357,16 +377,7 @@
 				else
 					if(BLOODBONDED.has_status_effect(STATUS_EFFECT_INLOVE))
 						BLOODBONDED.remove_status_effect(STATUS_EFFECT_INLOVE)
-//					else
-//						var/datum/preferences/P = GLOB.preferences_datums[ckey(H.key)]
-//						if(P)
-//							P.exper = min(calculate_mob_max_exper(H), P.exper+250)
-//						if(BLOODBONDED.key)
-//							var/datum/preferences/P2 = GLOB.preferences_datums[ckey(BLOODBONDED.key)]
-//							if(P2)
-//								P2.exper = min(calculate_mob_max_exper(BLOODBONDED), P2.exper+250)
 					BLOODBONDED.apply_status_effect(STATUS_EFFECT_INLOVE, owner)
-					H.bloodpool = max(0, H.bloodpool-2)
 					to_chat(owner, "<span class='notice'>You successfuly fed [BLOODBONDED] with vitae.</span>")
 					to_chat(BLOODBONDED, "<span class='userlove'>You feel good when you drink this <b>BLOOD</b>...</span>")
 					if(H.reagents)

--- a/code/modules/vtmb/kindred_species.dm
+++ b/code/modules/vtmb/kindred_species.dm
@@ -352,7 +352,7 @@
 										return
 
 						log_game("[key_name(H)] has Embraced [key_name(BLOODBONDED)].")
-						message_admins("[ADMIN_VERBOSEJMP(H)] has Embraced [ADMIN_VERBOSEJMP(BLOODBONDED)].")
+						message_admins("[ADMIN_LOOKUPFLW(H)] has Embraced [ADMIN_LOOKUPFLW(BLOODBONDED)].")
 						giving = FALSE
 						if(BLOODBONDED.revive(full_heal = TRUE, admin_revive = TRUE))
 							BLOODBONDED.grab_ghost(force = TRUE)

--- a/code/modules/vtmb/pyramid.dm
+++ b/code/modules/vtmb/pyramid.dm
@@ -221,7 +221,7 @@
 	faction = list("Tremere")
 
 /obj/ritualrune/question/complete()
-	visible_message("<span class='notice'>A call rings out to the dead...</span>")
+	visible_message("<span class='notice'>A call rings out to the dead from the [src.name] rune...</span>")
 	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you wish to answer a question? (You are allowed to spread meta information)", null, null, null, 10 SECONDS, src)
 	for(var/mob/dead/observer/G in GLOB.player_list)
 		if(G.key)
@@ -233,6 +233,8 @@
 		TR.name = C.name
 		playsound(loc, 'code/modules/wod13/sounds/thaum.ogg', 50, FALSE)
 		qdel(src)
+	else
+		visible_message("<span class='notice'>No one answers the [src.name] rune's call.</span>")
 
 /obj/ritualrune/teleport
 	name = "Teleportation Rune"

--- a/code/modules/vtmb/pyramid.dm
+++ b/code/modules/vtmb/pyramid.dm
@@ -221,7 +221,8 @@
 	faction = list("Tremere")
 
 /obj/ritualrune/question/complete()
-	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you wish to answer a question? (You are allowed to spread meta information)", null, null, null, 50, src)
+	visible_message("<span class='notice'>A call rings out to the dead...</span>")
+	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you wish to answer a question? (You are allowed to spread meta information)", null, null, null, 10 SECONDS, src)
 	for(var/mob/dead/observer/G in GLOB.player_list)
 		if(G.key)
 			to_chat(G, "<span class='ghostalert'>Question rune has been triggered.</span>")
@@ -229,6 +230,7 @@
 		var/mob/dead/observer/C = pick(candidates)
 		var/mob/living/simple_animal/hostile/ghost/tremere/TR = new(loc)
 		TR.key = C.key
+		TR.name = C.name
 		playsound(loc, 'code/modules/wod13/sounds/thaum.ogg', 50, FALSE)
 		qdel(src)
 

--- a/code/modules/vtmb/vampire_clane/doc.dm
+++ b/code/modules/vtmb/vampire_clane/doc.dm
@@ -10,7 +10,7 @@
 	male_clothes = "/obj/item/clothing/under/vampire/sexy"
 	female_clothes = "/obj/item/clothing/under/vampire/toreador/female"
 	enlightement = FALSE
-	whitelisted = FALSE
+	whitelisted = TRUE
 
 /datum/discipline/melpominee/post_gain(mob/living/carbon/human/H)
 	H.put_in_r_hand(new /obj/item/vamp/keys/daughters(H))

--- a/code/modules/vtmb/vampire_clane/lasombra.dm
+++ b/code/modules/vtmb/vampire_clane/lasombra.dm
@@ -10,7 +10,7 @@
 	male_clothes = "/obj/item/clothing/under/vampire/emo"
 	female_clothes = "/obj/item/clothing/under/vampire/business"
 	enlightement = TRUE
-	whitelisted = FALSE
+	whitelisted = TRUE
 
 /datum/vampireclane/lasombra/post_gain(mob/living/carbon/human/H)
 	..()

--- a/code/modules/vtmb/werewolf/auspice.dm
+++ b/code/modules/vtmb/werewolf/auspice.dm
@@ -9,8 +9,7 @@
 	var/base_breed = "Homid"
 	var/tribe = "Wendigo"
 	var/list/gifts = list()
-//	var/list/gifts2 = list()
-//	var/list/gifts3 = list()
+	var/force_abomination = FALSE
 
 	var/list/wendigo = list(
 		/datum/action/gift/stoic_pose = 1,

--- a/code/modules/wod13/bloodsucking.dm
+++ b/code/modules/wod13/bloodsucking.dm
@@ -38,7 +38,7 @@
 //		NPC.last_attacker = src
 
 	if(iskindred(mob))
-		to_chat(src, "<span class='userlove'>You notice a pleasant feeling while siping [mob]'s BLOOD...</span>")
+		to_chat(src, "<span class='userlove'>[mob]'s blood tastes HEAVENLY...</span>")
 		adjustBruteLoss(-25, TRUE)
 		adjustFireLoss(-25, TRUE)
 	else
@@ -46,14 +46,13 @@
 		to_chat(src, "<span class='warning'>You sip some <b>BLOOD</b> from your victim. It feels good.</span>")
 
 	if(mob.bloodpool <= 1 && mob.maxbloodpool > 1)
-//		if(alert("This action will kill your victim. Are you sure?",,"Yes","No")!="Yes")
-//			return
 		to_chat(src, "<span class='warning'>You feel small amount of <b>BLOOD</b> in your victim.</span>")
 		if(iskindred(mob))
 			if(!mob.client)
 				to_chat(src, "<span class='warning'>You need [mob]'s attention to do that...</span>")
 				return
-			message_admins("[src]([key]) is trying to diablerie [mob]([mob.key])!")
+			message_admins("[ADMIN_LOOKUPFLW(src)] is attempting to Diablerize [ADMIN_LOOKUPFLW(mob)]")
+			log_attack("[key_name(src)] is attempting to Diablerize [key_name(mob)].")
 			if(mob.key)
 				var/vse_taki = FALSE
 				var/special_role_name
@@ -138,11 +137,11 @@
 				if(iskindred(mob))
 					var/datum/preferences/P = GLOB.preferences_datums[ckey(key)]
 					var/datum/preferences/P2 = GLOB.preferences_datums[ckey(mob.key)]
-					message_admins("[src]([key]) tries to diablerie [mob](mob.key])!")
 					AdjustHumanity(-1, 0)
 					AdjustMasquerade(-1)
 					if(K.generation >= generation)
-						message_admins("[src]([key]) successes in diablerie over [mob](mob.key])!")
+						message_admins("[ADMIN_LOOKUPFLW(src)] successfully Diablerized [ADMIN_LOOKUPFLW(mob)]")
+						log_attack("[key_name(src)] successfully Diablerized [key_name(mob)].")
 						if(K.client)
 							K.generation = 13
 							P2.generation = 13
@@ -163,7 +162,8 @@
 							start_prob = 30
 						if(prob(min(99, start_prob+((generation-K.generation)*10))))
 							to_chat(src, "<span class='userdanger'><b>[K]'s SOUL OVERCOMES YOURS AND GAIN CONTROL OF YOUR BODY.</b></span>")
-							message_admins("[src]([key]) failed to diablerie [mob](mob.key])!")
+							message_admins("[ADMIN_LOOKUPFLW(src)] tried to Diablerize [ADMIN_LOOKUPFLW(mob)] and was overtaken.")
+							log_attack("[key_name(src)] tried to Diablerize [key_name(mob)] and was overtaken.")
 							generation = 13
 							death()
 							if(P)
@@ -176,7 +176,8 @@
 //							health = initial(health)+100*(13-generation)
 //							mob.death()
 						else
-							message_admins("[src]([key]) successes in diablerie over [mob](mob.key])!")
+							message_admins("[ADMIN_LOOKUPFLW(src)] successfully Diablerized [ADMIN_LOOKUPFLW(mob)]")
+							log_attack("[key_name(src)] successfully Diablerized [key_name(mob)].")
 							if(P)
 								P.diablerist = 1
 								P.generation = K.generation

--- a/code/modules/wod13/procs.dm
+++ b/code/modules/wod13/procs.dm
@@ -175,6 +175,57 @@
 		return TRUE
 	return FALSE
 
+/**
+ * Rolls a number of dice according to Storyteller system rules to find
+ * success or number of successes.
+ *
+ * Rolls a number of 10-sided dice, counting them as a "success" if
+ * they land on a number equal to or greater than the difficulty. Dice
+ * that land on 1 subtract a success from the total, and the minimum
+ * difficulty is 2. The number of successes is returned if numerical
+ * is true, or the roll outcome (botch, failure, success) as a defined
+ * number if false.
+ *
+ * Arguments:
+ * * dice - number of 10-sided dice to roll.
+ * * difficulty - the number that a dice must come up as to count as a success.
+ * * numerical - whether the proc returns number of successes or outcome (botch, failure, success)
+ */
+/proc/storyteller_roll(dice = 1, difficulty = 6, numerical = FALSE)
+	var/successes = 0
+	var/had_one = FALSE
+	var/had_success = FALSE
+
+	if (dice < 1)
+		if (numerical)
+			return 0
+		else
+			return ROLL_FAILURE
+
+	for (var/i in 1 to dice)
+		var/roll = rand(1, 10)
+
+		if (roll == 1)
+			successes--
+			if (!had_one)
+				had_one = TRUE
+			continue
+
+		if (roll >= difficulty)
+			successes++
+			if (!had_success)
+				had_success = TRUE
+
+	if (numerical)
+		return successes
+	else
+		if (!had_success && had_one)
+			return ROLL_BOTCH
+		else if (successes <= 0)
+			return ROLL_FAILURE
+		else
+			return ROLL_SUCCESS
+
 /proc/vampireroll(var/dices_num = 1, var/hardness = 1, var/atom/rollviewer)
 	var/wins = 0
 	var/crits = 0

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -135,6 +135,7 @@
 #include "code\__DEFINES\vv.dm"
 #include "code\__DEFINES\wall_dents.dm"
 #include "code\__DEFINES\wires.dm"
+#include "code\__DEFINES\wod13.dm"
 #include "code\__DEFINES\wounds.dm"
 #include "code\__DEFINES\dcs\flags.dm"
 #include "code\__DEFINES\dcs\helpers.dm"


### PR DESCRIPTION
## About The Pull Request
This PR is an amalgam of different changes that I was working on today.
- Adds in a dice rolling system for both number of successes and outcome of the roll. 
- Makes Melpominee 2 come up as a forced say in admin logs.
- Makes everyone witnessing Melpominee 2 roll with Mentality to realise that the victim's lips don't match what they're saying. Base difficulty 5, +2 difficulty if the victim is wearing a mask, +1 difficulty if the witness is more than 3 tiles away, and +2 difficulty if the victim is currently typing.
- Adds rudimentary admin logging for all Disciplines.
- Adds text explaining what happened when you Wight.
- Trying to embrace a Garou now rolls their Auspice level, only allowing the Embrace on a botch. They scrunch or stay perfectly still on failure and success.
- Allows admins to forcefully allow the Embrace of a Garou by setting their auspice.force_abomination variable to 1.
- Makes the Tremere ghost rune display some messages explaining what it's doing, and summon ghosts with their actual names.
- Whitelists Lasombra and Daughters of Cacophony.

## Why It's Good For The Game
Just making the game better overall. Making some stuff lore-accurate, fixing some bugs, explaining some stuff, preventing some random issues, making life easier for admins, the whole gamut.

## Changelog
:cl:
code: Add a dice rolling system, with a parameter to choose whether it returns the outcome or number of successes.
tweak: Whitelists Lasombra and Daughters of Cacophony.
tweak: Adds a message explaining what happened when you Wight.
tweak: Melpominee 1 and 2 have switched places. Melpominee 2 can now project your voice to anyone in the server.
balance: Melpominee 1 can now be detected, with several factors like them wearing a mask or typing or being far away from you affecting your ability to do so.
add: Garou now resist the Embrace with their Auspice level. They can only be made into an Abomination on a botch. You have one try.
code: Removed a bunch of useless commented out code.
admin: Discipline casts are now logged, and Melpominee 2 is correctly logged as a force say.
admin: You can forcefully allow a Garou to be Embraced by setting their auspice.force_abomination variable to 1.
/:cl: