### PR TITLE
Temporal Tampering - Bullettime

### DIFF
--- a/code/__DEFINES/melee.dm
+++ b/code/__DEFINES/melee.dm
@@ -8,3 +8,4 @@
 #define MARTIALART_KRAVMAGA "krav maga"
 #define MARTIALART_CQC "CQC"
 #define MARTIALART_PLASMAFIST "plasma fist"
+#define MARTIALART_COWALKER "cowalker"

--- a/code/datums/martial/cowalker.dm
+++ b/code/datums/martial/cowalker.dm
@@ -1,0 +1,19 @@
+/datum/martial_art/cowalker
+	name = "Cowalker"
+	id = MARTIALART_COWALKER
+	allow_temp_override = FALSE
+
+/datum/martial_art/cowalker/on_projectile_hit(mob/living/A, obj/projectile/P, def_zone)
+	. = ..()
+	if(iskindred(A) && A.temporis_visual == TRUE)
+		if(prob(75))
+			A.visible_message("<span class='danger'>The projectiles seem to phase through [A]! You shot at the wrong copy!</span>", "<span class='userdanger'>They shot the wrong you!</span>")
+			playsound(get_turf(A), pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 75, TRUE)
+			return BULLET_ACT_FORCE_PIERCE
+		return BULLET_ACT_HIT
+	else if(iskindred(A) && A.temporis_blur == TRUE)
+		A.visible_message("<span class='danger'>[A] moved out of the way before you even pulled the trigger! They can move faster than your shots!</span>", "<span class='userdanger'>You stepped out of the way of the bullets!</span>")
+		playsound(get_turf(A), pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 75, TRUE)
+		return BULLET_ACT_FORCE_PIERCE
+
+	return BULLET_ACT_HIT

--- a/code/modules/vtmb/vampire_clane/true_brujah.dm
+++ b/code/modules/vtmb/vampire_clane/true_brujah.dm
@@ -36,6 +36,8 @@
 	. = ..()
 	to_chat(usr, "<b>[SScity_time.timeofnight]</b>")
 
+var/datum/martial_art/cowalker/style
+
 /datum/action/temporis_step
 	name = "Cowalker"
 	desc = "Stop time for a moment in order to appear in two places at once."
@@ -45,6 +47,7 @@
 	var/spam_fix = 0
 
 /proc/tempstep(mob/living/M)
+	style = new
 	if(M.temporis_visual)
 		return
 	M.temporis_visual = TRUE
@@ -57,7 +60,9 @@
 	animate(M, transform = initial_matrix, time = 10, loop = 0)
 	animate(M, transform = secondary_matrix, time = 10, loop = 0, ANIMATION_PARALLEL)
 	animate(M, transform = tertiary_matrix, time = 10, loop = 0, ANIMATION_PARALLEL)
+	style.teach(M, make_temporary = TRUE)
 	spawn(10 SECONDS)
+		style.remove(M)
 		M.temporis_visual = FALSE
 		playsound(M.loc, 'code/modules/wod13/sounds/temporis end.ogg', 50, FALSE)
 
@@ -83,13 +88,16 @@
 	var/spam_fix = 0
 
 /proc/clothogift(mob/living/M)
+	style = new
 	if(M.temporis_blur)
 		return
 	M.temporis_blur = TRUE
 	M.add_movespeed_modifier(/datum/movespeed_modifier/temporis5)
 	M.next_move_modifier *= TEMPORIS_ATTACK_SPEED_MODIFIER
+	style.teach(M, make_temporary = TRUE)
 	spawn(10 SECONDS)
 		if(usr == M)
+			style.remove(M)
 			M.temporis_blur = FALSE
 			M.playsound_local(M.loc, 'code/modules/wod13/sounds/temporis end.ogg', 50, FALSE)
 			M.remove_movespeed_modifier(/datum/movespeed_modifier/temporis5)
@@ -97,7 +105,7 @@
 
 
 /datum/action/clotho/Trigger()
-	if(spam_fix + 20 SECONDS > world.time)
+	if(spam_fix + 15 SECONDS > world.time)
 		return
 	var/mob/living/carbon/human/H = owner
 	if(H.bloodpool < 3)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -681,6 +681,7 @@
 #include "code\datums\martial\psychotic_brawl.dm"
 #include "code\datums\martial\sleeping_carp.dm"
 #include "code\datums\martial\wrestling.dm"
+#include "code\datums\martial\cowalker.dm"
 #include "code\datums\materials\_material.dm"
 #include "code\datums\materials\alloys.dm"
 #include "code\datums\materials\basemats.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds bullet dodge chance to temporis 4, and full bullet dodge to temporis 5
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Right now temporis 4 is virtually a useless ability, unless someone is really awful at clicking on you. This gives it utility it did not have before, while still not being perfect. Temporis 5 is not clearly advertised enough as being separate from celerity, and is not a risk to use in public currently, now, if a true brujah uses it in public and is shot at, they will 'step out of the way' of bullets, revealing themselves to some degree. Temporis 5 is also the most expensive power in the game currently, bloodpoint wise.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added bullet dodge abilities to some temporis levels
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
