### PR TITLE
Dance Dance Dance til' you're dead - wait not like that

### DIFF
--- a/code/modules/wod13/quirks.dm
+++ b/code/modules/wod13/quirks.dm
@@ -370,6 +370,13 @@ Dancer
 	var/last_added_humanity = 0
 
 /datum/action/dance/Trigger()
+	if(HAS_TRAIT(owner, TRAIT_INCAPACITATED))
+		to_chat(owner, "<span class='warning'>You're a little too close to being dead to get down!</span>")
+		return
+
+	if(HAS_TRAIT(owner, TRAIT_FLOORED))
+		to_chat(owner, "<span class='warning'>You got to get up before you get down!</span>")
+		return
 //	var/mob/living/carbon/H = owner
 	if(prob(50))
 		dancefirst(owner)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the ability to use the dance emote while crit or knocked over and unable to get up
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
using quirk actions as not-intended makes it harder to hit people who are almost dead or are incapacitated in combat, which is not super fun for those that don't have the quirk!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: You can no longer dance while dying/knocked over
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
