### PR TITLE
Gets rid of Cham Injector for Vic

### DIFF
--- a/code/modules/vtmb/vampire_clane/tzimisce.dm
+++ b/code/modules/vtmb/vampire_clane/tzimisce.dm
@@ -229,7 +229,7 @@
 			H.mind.teach_crafting_recipe(/datum/crafting_recipe/tzi_heart)
 			H.mind.teach_crafting_recipe(/datum/crafting_recipe/tzi_koldun)
 		if(level >= 5)
-			H.mind.teach_crafting_recipe(/datum/crafting_recipe/tzi_stealth)
+//			H.mind.teach_crafting_recipe(/datum/crafting_recipe/tzi_stealth)
 			H.mind.teach_crafting_recipe(/datum/crafting_recipe/tzi_trench)
 
 /datum/vampireclane/tzimisce/post_gain(mob/living/carbon/human/H)
@@ -300,7 +300,7 @@
 	result = /obj/item/organ/eyes/night_vision/nightmare
 	always_available = FALSE
 	category = CAT_TZIMISCE
-
+/*
 /datum/crafting_recipe/tzi_stealth
 	name = "Stealth Skin (Invisibility)"
 	time = 50
@@ -308,7 +308,7 @@
 	result = /obj/item/dnainjector/chameleonmut
 	always_available = FALSE
 	category = CAT_TZIMISCE
-
+*/
 /datum/crafting_recipe/tzi_koldun
 	name = "Koldun Sorcery (Firebreath)"
 	time = 50


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This comments out the vicissitude chameleon injector from the crafting menu and code.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Everyone who has used it has complained about it being inconsistent, as well as the noises it makes, this solves both problems.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed vic chameleon injector
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
