### PR TITLE
Fixes not being able to make urn a second time

### DIFF
--- a/code/modules/vtmb/vampire_clane/ministry.dm
+++ b/code/modules/vtmb/vampire_clane/ministry.dm
@@ -96,6 +96,7 @@
 						heart.Insert(H)
 			urn.own = null
 			qdel(urn)
+			urn = null
 
 /datum/action/mummyfy
 	name = "Mummyfy"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This fixes the previous inability to make the urn a second time. The qdel at the end of the urn action trigger deleted the variable's reference as well, adding a redefinition of urn afterwards fixes this.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Urn on, Urn off
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed bug involving urn creation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
