### PR TITLE
Small Garou Gift/Misc Tweaks + THE GLASSWALKER NERF 2.0 [Draftless Draft]

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -145,6 +145,7 @@
 	var/inspired = FALSE
 
 	var/tox_damage_plus = 0
+	var/agg_damage_plus = 0
 
 	var/lock_on_by_mannequin = FALSE
 

--- a/code/modules/mob/living/carbon/werewolf/lupus.dm
+++ b/code/modules/mob/living/carbon/werewolf/lupus.dm
@@ -25,7 +25,7 @@
 //		)
 
 /datum/movespeed_modifier/lupusform
-	multiplicative_slowdown = -0.85
+	multiplicative_slowdown = -0.8
 
 /mob/living/carbon/werewolf/lupus/update_icons()
 	cut_overlays()

--- a/code/modules/mob/living/carbon/werewolf/werewolf.dm
+++ b/code/modules/mob/living/carbon/werewolf/werewolf.dm
@@ -187,7 +187,7 @@
 	limb_destroyer = 1
 	hud_type = /datum/hud/werewolf
 	melee_damage_lower = 25
-	melee_damage_upper = 65
+	melee_damage_upper = 60
 	health = 300
 	maxHealth = 300
 //	speed = -1  doesn't work on carbons
@@ -206,10 +206,10 @@
 		/obj/item/bodypart/l_leg,
 		)
 
-	werewolf_armor = 35
+	werewolf_armor = 30
 
 /datum/movespeed_modifier/crinosform
-	multiplicative_slowdown = -0.25
+	multiplicative_slowdown = -0.2
 
 /datum/movespeed_modifier/silver_slowdown
 	multiplicative_slowdown = 0.3

--- a/code/modules/mob/living/carbon/werewolf/werewolf_defense.dm
+++ b/code/modules/mob/living/carbon/werewolf/werewolf_defense.dm
@@ -20,8 +20,10 @@
 			grabbedby(M)
 		if ("harm")
 			M.do_attack_animation(src, ATTACK_EFFECT_PUNCH)
-			if(M.tox_damage_plus)
+			if(tox_damage_plus)
 				adjustToxLoss(M.tox_damage_plus)
+			if(agg_damage_plus)
+				adjustCloneLoss(M.agg_damage_plus)
 			return TRUE
 		if("disarm")
 			M.do_attack_animation(src, ATTACK_EFFECT_DISARM)
@@ -88,7 +90,7 @@
 									"<span class='userdanger'>[M] punches you!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", COMBAT_MESSAGE_RANGE, M)
 					to_chat(M, "<span class='danger'>You punch [src]!</span>")
 					if ((stat != DEAD) && (damage > 9 || prob(5)))//Regular humans have a very small chance of knocking an alien down.
-						Unconscious(40)
+						Unconscious(30)
 						visible_message("<span class='danger'>[M] knocks [src] down!</span>", \
 										"<span class='userdanger'>[M] knocks you down!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", null, M)
 						to_chat(M, "<span class='danger'>You knock [src] down!</span>")
@@ -104,7 +106,7 @@
 			if ("disarm")
 				if (body_position == STANDING_UP)
 					if (prob(5))
-						Unconscious(40)
+						Unconscious(30)
 						playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, TRUE, -1)
 						log_combat(M, src, "pushed")
 						visible_message("<span class='danger'>[M] pushes [src] down!</span>", \

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -345,12 +345,13 @@
 	footstep_type = FOOTSTEP_MOB_CLAW
 	bloodpool = 1
 	maxbloodpool = 1
-	maxHealth = 30
-	health = 30
+	maxHealth = 40
+	health = 40
 	harm_intent_damage = 20
 	melee_damage_lower = 15
 	melee_damage_upper = 30
 	speed = -0.1
+	dodging = TRUE
 
 /mob/living/simple_animal/hostile/beastmaster/cat/Initialize()
 	. = ..()

--- a/code/modules/vtmb/npc/beastmaster.dm
+++ b/code/modules/vtmb/npc/beastmaster.dm
@@ -81,8 +81,8 @@ SUBSYSTEM_DEF(beastmastering)
 //	move_to_delay = 3
 //	rapid = 3
 //	ranged = 1
-	maxHealth = 80
-	health = 85
+	maxHealth = 95
+	health = 95
 	harm_intent_damage = 5
 	melee_damage_lower = 10
 	melee_damage_upper = 25

--- a/code/modules/vtmb/vampire_clane/tzimisce.dm
+++ b/code/modules/vtmb/vampire_clane/tzimisce.dm
@@ -635,10 +635,10 @@
 /mob/living/simple_animal/hostile/biter/lasombra/better
 	icon_state = "shadow2"
 	icon_living = "shadow2"
-	maxHealth = 200
-	health = 200
-	melee_damage_lower = 50
-	melee_damage_upper = 50
+	maxHealth = 150
+	health = 150
+	melee_damage_lower = 30
+	melee_damage_upper = 30
 
 /mob/living/simple_animal/hostile/fister
 	name = "fister"
@@ -807,13 +807,13 @@
 	pixel_z = -16
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
 	speak_chance = 0
-	speed = -1
+	speed = -0.6
 	maxHealth = 575
 	health = 575
 	butcher_results = list(/obj/item/stack/human_flesh = 20)
 	harm_intent_damage = 5
-	melee_damage_lower = 70
-	melee_damage_upper = 70
+	melee_damage_lower = 45
+	melee_damage_upper = 60
 	attack_verb_continuous = "slashes"
 	attack_verb_simple = "slash"
 	attack_sound = 'sound/weapons/slash.ogg'
@@ -837,8 +837,8 @@
 	health = 100
 	butcher_results = list(/obj/item/stack/human_flesh = 20)
 	harm_intent_damage = 5
-	melee_damage_lower = 1
-	melee_damage_upper = 1
+	melee_damage_lower = 10
+	melee_damage_upper = 10
 	attack_verb_continuous = "slashes"
 	attack_verb_simple = "slash"
 	attack_sound = 'sound/weapons/slash.ogg'

--- a/code/modules/vtmb/werewolf/gifts.dm
+++ b/code/modules/vtmb/werewolf/gifts.dm
@@ -59,7 +59,7 @@
 	. = ..()
 	if(inspired)
 		if(stat != DEAD)
-			adjustBruteLoss(-4, TRUE)
+			adjustBruteLoss(-10, TRUE)
 			var/obj/effect/celerity/C = new(get_turf(src))
 			C.appearance = appearance
 			C.dir = dir
@@ -114,8 +114,8 @@
 		else
 			playsound(get_turf(owner), 'code/modules/wod13/sounds/razor_claws.ogg', 75, FALSE)
 			var/mob/living/carbon/H = owner
-			H.melee_damage_lower = H.melee_damage_lower+20
-			H.melee_damage_upper = H.melee_damage_upper+20
+			H.melee_damage_lower = H.melee_damage_lower+15
+			H.melee_damage_upper = H.melee_damage_upper+15
 			H.agg_damage_plus = 2.5
 			to_chat(owner, "<span class='notice'>You feel your claws sharpening...</span>")
 			spawn(10 SECONDS)

--- a/code/modules/vtmb/werewolf/gifts.dm
+++ b/code/modules/vtmb/werewolf/gifts.dm
@@ -104,7 +104,7 @@
 			H.dna.species.punchdamagelow = 25
 			H.dna.species.punchdamagehigh = 25
 			to_chat(owner, "<span class='notice'>You feel your claws sharpening...</span>")
-			spawn(150)
+			spawn(10 SECONDS)
 				H.dna.species.attack_verb = initial(H.dna.species.attack_verb)
 				H.dna.species.attack_sound = initial(H.dna.species.attack_sound)
 				H.dna.species.miss_sound = initial(H.dna.species.miss_sound)
@@ -116,8 +116,10 @@
 			var/mob/living/carbon/H = owner
 			H.melee_damage_lower = H.melee_damage_lower+20
 			H.melee_damage_upper = H.melee_damage_upper+20
+			H.agg_damage_plus = 2.5
 			to_chat(owner, "<span class='notice'>You feel your claws sharpening...</span>")
-			spawn(150)
+			spawn(10 SECONDS)
+				H.agg_damage_plus = 0
 				H.melee_damage_lower = initial(H.melee_damage_lower)
 				H.melee_damage_upper = initial(H.melee_damage_upper)
 				to_chat(owner, "<span class='warning'>Your claws are not sharp anymore...</span>")
@@ -198,19 +200,19 @@
 		if(ishuman(owner))
 			playsound(get_turf(owner), 'code/modules/wod13/sounds/resist_pain.ogg', 75, FALSE)
 			var/mob/living/carbon/human/H = owner
-			H.physiology.armor.melee = 50
-			H.physiology.armor.bullet = 50
+			H.physiology.armor.melee = 45
+			H.physiology.armor.bullet = 45
 			to_chat(owner, "<span class='notice'>You feel your skin thickering...</span>")
-			spawn(200)
+			spawn(12 SECONDS)
 				H.physiology.armor.melee = initial(H.physiology.armor.melee)
 				H.physiology.armor.bullet = initial(H.physiology.armor.bullet)
 				to_chat(owner, "<span class='warning'>Your skin is thin again...</span>")
 		else
 			playsound(get_turf(owner), 'code/modules/wod13/sounds/resist_pain.ogg', 75, FALSE)
 			var/mob/living/carbon/werewolf/H = owner
-			H.werewolf_armor = 50
+			H.werewolf_armor = 45
 			to_chat(owner, "<span class='notice'>You feel your skin thickering...</span>")
-			spawn(200)
+			spawn(12 SECONDS)
 				H.werewolf_armor = initial(H.werewolf_armor)
 				to_chat(owner, "<span class='warning'>Your skin is thin again...</span>")
 
@@ -347,10 +349,11 @@
 		var/mob/living/carbon/C = owner
 		if(C.stat != DEAD)
 			SEND_SOUND(owner, sound('code/modules/wod13/sounds/rage_heal.ogg', 0, 0, 75))
-			C.adjustBruteLoss(-50*C.auspice.level, TRUE)
+			C.adjustBruteLoss(-45*C.auspice.level, TRUE)
 			C.adjustFireLoss(-35*C.auspice.level, TRUE)
-			C.adjustCloneLoss(-25*C.auspice.level, TRUE)
-			C.adjustOxyLoss(-25*C.auspice.level, TRUE)
+			C.adjustCloneLoss(-15*C.auspice.level, TRUE)
+			C.adjustOxyLoss(-20*C.auspice.level, TRUE)
+			C.adjustToxLoss(-5*C.auspice.level, TRUE)
 			C.bloodpool = min(C.bloodpool + C.auspice.level, C.maxbloodpool)
 			C.blood_volume = min(C.blood_volume + 56 * C.auspice.level, BLOOD_VOLUME_NORMAL)
 			if(ishuman(owner))

--- a/code/modules/vtmb/werewolf/gifts.dm
+++ b/code/modules/vtmb/werewolf/gifts.dm
@@ -200,8 +200,8 @@
 		if(ishuman(owner))
 			playsound(get_turf(owner), 'code/modules/wod13/sounds/resist_pain.ogg', 75, FALSE)
 			var/mob/living/carbon/human/H = owner
-			H.physiology.armor.melee = 45
-			H.physiology.armor.bullet = 45
+			H.physiology.armor.melee = 35
+			H.physiology.armor.bullet = 20
 			to_chat(owner, "<span class='notice'>You feel your skin thickering...</span>")
 			spawn(12 SECONDS)
 				H.physiology.armor.melee = initial(H.physiology.armor.melee)
@@ -210,7 +210,7 @@
 		else
 			playsound(get_turf(owner), 'code/modules/wod13/sounds/resist_pain.ogg', 75, FALSE)
 			var/mob/living/carbon/werewolf/H = owner
-			H.werewolf_armor = 45
+			H.werewolf_armor = 35
 			to_chat(owner, "<span class='notice'>You feel your skin thickering...</span>")
 			spawn(12 SECONDS)
 				H.werewolf_armor = initial(H.werewolf_armor)
@@ -349,8 +349,8 @@
 		var/mob/living/carbon/C = owner
 		if(C.stat != DEAD)
 			SEND_SOUND(owner, sound('code/modules/wod13/sounds/rage_heal.ogg', 0, 0, 75))
-			C.adjustBruteLoss(-45*C.auspice.level, TRUE)
-			C.adjustFireLoss(-35*C.auspice.level, TRUE)
+			C.adjustBruteLoss(-40*C.auspice.level, TRUE)
+			C.adjustFireLoss(-30*C.auspice.level, TRUE)
 			C.adjustCloneLoss(-15*C.auspice.level, TRUE)
 			C.adjustOxyLoss(-20*C.auspice.level, TRUE)
 			C.adjustToxLoss(-5*C.auspice.level, TRUE)

--- a/code/modules/vtmb/werewolf/tribes.dm
+++ b/code/modules/vtmb/werewolf/tribes.dm
@@ -11,23 +11,23 @@
 		var/mob/living/carbon/C = owner
 		if(isgarou(C))
 			var/obj/were_ice/W = new (get_turf(owner))
-			C.Stun(200)
+			C.Stun(12 SECONDS)
 			C.forceMove(W)
-			spawn(200)
+			spawn(12 SECONDS)
 				C.forceMove(get_turf(W))
 				qdel(W)
 		if(iscrinos(C))
 			var/obj/were_ice/crinos/W = new (get_turf(owner))
-			C.Stun(200)
+			C.Stun(12 SECONDS)
 			C.forceMove(W)
-			spawn(200)
+			spawn(12 SECONDS)
 				C.forceMove(get_turf(W))
 				qdel(W)
 		if(islupus(C))
 			var/obj/were_ice/lupus/W = new (get_turf(owner))
-			C.Stun(200)
+			C.Stun(12 SECONDS)
 			C.forceMove(W)
-			spawn(200)
+			spawn(12 SECONDS)
 				C.forceMove(get_turf(W))
 				qdel(W)
 
@@ -46,7 +46,7 @@
 				var/obj/effect/wind/W = new(T)
 				W.dir = owner.dir
 				W.strength = 100
-				spawn(200)
+				spawn(20 SECONDS)
 					qdel(W)
 //	if(allowed_to_proceed)
 
@@ -95,19 +95,19 @@
 		if(ishuman(owner))
 			playsound(get_turf(owner), 'code/modules/wod13/sounds/venom_claws.ogg', 75, FALSE)
 			var/mob/living/carbon/human/H = owner
-			H.tox_damage_plus = 25
+			H.tox_damage_plus = 15
 			to_chat(owner, "<span class='notice'>You feel your claws filling with pure venom...</span>")
-			spawn(150)
+			spawn(15 SECONDS)
 				H.tox_damage_plus = 0
 				to_chat(owner, "<span class='warning'>Your claws are not poison anymore...</span>")
 		else
 			playsound(get_turf(owner), 'code/modules/wod13/sounds/venom_claws.ogg', 75, FALSE)
 			var/mob/living/carbon/H = owner
-			H.melee_damage_lower = initial(H.melee_damage_lower)+20
-			H.melee_damage_upper = initial(H.melee_damage_upper)+20
-			H.tox_damage_plus = 25
+			H.melee_damage_lower = initial(H.melee_damage_lower)+10
+			H.melee_damage_upper = initial(H.melee_damage_upper)+10
+			H.tox_damage_plus = 15
 			to_chat(owner, "<span class='notice'>You feel your claws filling with pure venom...</span>")
-			spawn(150)
+			spawn(15 SECONDS)
 				H.tox_damage_plus = 0
 				H.melee_damage_lower = initial(H.melee_damage_lower)
 				H.melee_damage_upper = initial(H.melee_damage_upper)
@@ -125,7 +125,7 @@
 		if(do_after(owner, 3 SECONDS))
 			for(var/mob/living/L in orange(5, owner))
 				if(L)
-					L.adjustFireLoss(40)
+					L.adjustFireLoss(35)
 			for(var/turf/T in orange(4, get_turf(owner)))
 				var/obj/effect/fire/F = new(T)
 				spawn(5)
@@ -177,8 +177,8 @@
 		if(ishuman(owner))
 			playsound(get_turf(owner), 'code/modules/wod13/sounds/electro_cast.ogg', 75, FALSE)
 			var/mob/living/carbon/human/H = owner
-			H.physiology.armor.melee = 99
-			H.physiology.armor.bullet = 99
+			H.physiology.armor.melee = 50
+			H.physiology.armor.bullet = 50
 			to_chat(owner, "<span class='notice'>You feel your skin replaced with the machine...</span>")
 			spawn(100)
 				H.physiology.armor.melee = initial(H.physiology.armor.melee)
@@ -188,7 +188,7 @@
 		else
 			playsound(get_turf(owner), 'code/modules/wod13/sounds/electro_cast.ogg', 75, FALSE)
 			var/mob/living/carbon/werewolf/H = owner
-			H.werewolf_armor = 99
+			H.werewolf_armor = 55
 			to_chat(owner, "<span class='notice'>You feel your skin replaced with the machine...</span>")
 			spawn(100)
 				H.werewolf_armor = initial(H.werewolf_armor)

--- a/code/modules/vtmb/werewolf/tribes.dm
+++ b/code/modules/vtmb/werewolf/tribes.dm
@@ -96,22 +96,22 @@
 			playsound(get_turf(owner), 'code/modules/wod13/sounds/venom_claws.ogg', 75, FALSE)
 			var/mob/living/carbon/human/H = owner
 			H.tox_damage_plus = 15
-			to_chat(owner, "<span class='notice'>You feel your claws filling with pure venom...</span>")
+			to_chat(owner, "<span class='notice'>You feel your claws seeping with pure venom...</span>")
 			spawn(12 SECONDS)
 				H.tox_damage_plus = 0
-				to_chat(owner, "<span class='warning'>Your claws are not poison anymore...</span>")
+				to_chat(owner, "<span class='warning'>Your claws dry of their venom coating...</span>")
 		else
 			playsound(get_turf(owner), 'code/modules/wod13/sounds/venom_claws.ogg', 75, FALSE)
 			var/mob/living/carbon/H = owner
 			H.melee_damage_lower = initial(H.melee_damage_lower)+10
 			H.melee_damage_upper = initial(H.melee_damage_upper)+10
 			H.tox_damage_plus = 15
-			to_chat(owner, "<span class='notice'>You feel your claws filling with pure venom...</span>")
+			to_chat(owner, "<span class='notice'>You feel your claws seeping with pure venom...</span>")
 			spawn(12 SECONDS)
 				H.tox_damage_plus = 0
 				H.melee_damage_lower = initial(H.melee_damage_lower)
 				H.melee_damage_upper = initial(H.melee_damage_upper)
-				to_chat(owner, "<span class='warning'>Your claws are not poison anymore...</span>")
+				to_chat(owner, "<span class='warning'>Your claws dry of their venom coating...</span>")
 
 /datum/action/gift/burning_scars
 	name = "Burning Scars"

--- a/code/modules/vtmb/werewolf/tribes.dm
+++ b/code/modules/vtmb/werewolf/tribes.dm
@@ -97,7 +97,7 @@
 			var/mob/living/carbon/human/H = owner
 			H.tox_damage_plus = 15
 			to_chat(owner, "<span class='notice'>You feel your claws filling with pure venom...</span>")
-			spawn(15 SECONDS)
+			spawn(12 SECONDS)
 				H.tox_damage_plus = 0
 				to_chat(owner, "<span class='warning'>Your claws are not poison anymore...</span>")
 		else
@@ -107,7 +107,7 @@
 			H.melee_damage_upper = initial(H.melee_damage_upper)+10
 			H.tox_damage_plus = 15
 			to_chat(owner, "<span class='notice'>You feel your claws filling with pure venom...</span>")
-			spawn(15 SECONDS)
+			spawn(12 SECONDS)
 				H.tox_damage_plus = 0
 				H.melee_damage_lower = initial(H.melee_damage_lower)
 				H.melee_damage_upper = initial(H.melee_damage_upper)
@@ -177,8 +177,8 @@
 		if(ishuman(owner))
 			playsound(get_turf(owner), 'code/modules/wod13/sounds/electro_cast.ogg', 75, FALSE)
 			var/mob/living/carbon/human/H = owner
-			H.physiology.armor.melee = 50
-			H.physiology.armor.bullet = 50
+			H.physiology.armor.melee = 25
+			H.physiology.armor.bullet = 35
 			to_chat(owner, "<span class='notice'>You feel your skin replaced with the machine...</span>")
 			spawn(100)
 				H.physiology.armor.melee = initial(H.physiology.armor.melee)
@@ -188,7 +188,7 @@
 		else
 			playsound(get_turf(owner), 'code/modules/wod13/sounds/electro_cast.ogg', 75, FALSE)
 			var/mob/living/carbon/werewolf/H = owner
-			H.werewolf_armor = 55
+			H.werewolf_armor = 40
 			to_chat(owner, "<span class='notice'>You feel your skin replaced with the machine...</span>")
 			spawn(100)
 				H.werewolf_armor = initial(H.werewolf_armor)

--- a/code/modules/wod13/npcroles.dm
+++ b/code/modules/wod13/npcroles.dm
@@ -871,6 +871,7 @@
 	melee_damage_lower = 10
 	melee_damage_upper = 10
 	speed = 0
+	dodging = TRUE
 
 /mob/living/simple_animal/hostile/beastmaster/rat/Initialize()
 	. = ..()
@@ -892,7 +893,7 @@
 	if(ishuman(A))
 		var/mob/living/carbon/human/H = A
 		if(H.bloodpool)
-			if(prob(25))
+			if(prob(15))
 				H.bloodpool = max(0, H.bloodpool-1)
 				beastmaster.bloodpool = min(beastmaster.maxbloodpool, beastmaster.bloodpool+1)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adjusts some values mostly closer to originals, exchanges deciseconds for real numbers, attempts to **fix venom claws** (UNFIXED DO NOT MERGE) and violently tones down glasswalker tribe gift.
Also touches some simple mobs after seeing lasombra shadow minion spam, bats being too blood bitey etc.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
One certain tribe is no longer legitimately OP.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds small amount of agg to razor claws. (ALSO NOT WORKING UNTIL THE TOXIN CLAWS WORK)
tweak: tweaked garou waking up from the 5% knockout punch a tiny bit quicker (celerity exists)
tweak: cats, bats, rats and dogs again
balance: rebalanced armour values on resist pain and elemental improvement.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
