### PR TITLE
Add Physique Scale to Grab 

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -938,7 +938,15 @@
 		if((resting || HAS_TRAIT(src, TRAIT_GRABWEAKNESS)) && pulledby.grab_state < GRAB_KILL) //If resting, resisting out of a grab is equivalent to 1 grab state higher. won't make the grab state exceed the normal max, however
 			altered_grab_state++
 		var/resist_chance = BASE_GRAB_RESIST_CHANCE /// see defines/combat.dm, this should be baseline 60%
-		resist_chance = (resist_chance/altered_grab_state) ///Resist chance divided by the value imparted by your grab state. It isn't until you reach neckgrab that you gain a penalty to escaping a grab.
+		var/mob/living/G = pulledby
+		var/grabber_physique = (G.physique + G.additional_physique) * 10 // The one who is grabbing physique
+		var/resist_physique = (physique + additional_physique) * 10 /// The one who is  resisting physique
+		if(grabber_physique > resist_physique)
+			resist_chance = ((resist_chance - (grabber_physique - resist_physique))/altered_grab_state) ///Resist chance divided by the value imparted by your grab state. It isn't until you reach neckgrab that you gain a penalty to escaping a grab.
+		else if(grabber_physique < resist_physique)
+			resist_chance = ((resist_chance + (resist_physique - grabber_physique))/altered_grab_state) // WoD Calculations for resist chance based on the players or npcs Physique Stat.
+		else
+			resist_chance = (resist_chance/altered_grab_state)
 		if(prob(resist_chance))
 			visible_message("<span class='danger'>[src] breaks free of [pulledby]'s grip!</span>", \
 							"<span class='danger'>You break free of [pulledby]'s grip!</span>", null, null, pulledby)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -942,7 +942,8 @@
 		var/grabber_physique = (G.physique + G.additional_physique) * 10 // The one who is grabbing physique
 		var/resist_physique = (physique + additional_physique) * 10 /// The one who is  resisting physique
         resist_chance = (resist_chance + (resist_physique - grabber_physique))/altered_grab_state
-		if(prob(resist_chance))
+		var/resist_physique = (physique + additional_physique) * 10 // The one who is  resisting physique
+		resist_chance = ((resist_chance + (resist_physique - grabber_physique))/altered_grab_state)
 			visible_message("<span class='danger'>[src] breaks free of [pulledby]'s grip!</span>", \
 							"<span class='danger'>You break free of [pulledby]'s grip!</span>", null, null, pulledby)
 			to_chat(pulledby, "<span class='warning'>[src] breaks free of your grip!</span>")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -941,12 +941,7 @@
 		var/mob/living/G = pulledby
 		var/grabber_physique = (G.physique + G.additional_physique) * 10 // The one who is grabbing physique
 		var/resist_physique = (physique + additional_physique) * 10 /// The one who is  resisting physique
-		if(grabber_physique > resist_physique)
-			resist_chance = ((resist_chance - (grabber_physique - resist_physique))/altered_grab_state) ///Resist chance divided by the value imparted by your grab state. It isn't until you reach neckgrab that you gain a penalty to escaping a grab.
-		else if(grabber_physique < resist_physique)
-			resist_chance = ((resist_chance + (resist_physique - grabber_physique))/altered_grab_state) // WoD Calculations for resist chance based on the players or npcs Physique Stat.
-		else
-			resist_chance = (resist_chance/altered_grab_state)
+        resist_chance = (resist_chance + (resist_physique - grabber_physique))/altered_grab_state
 		if(prob(resist_chance))
 			visible_message("<span class='danger'>[src] breaks free of [pulledby]'s grip!</span>", \
 							"<span class='danger'>You break free of [pulledby]'s grip!</span>", null, null, pulledby)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -940,10 +940,9 @@
 		var/resist_chance = BASE_GRAB_RESIST_CHANCE /// see defines/combat.dm, this should be baseline 60%
 		var/mob/living/G = pulledby
 		var/grabber_physique = (G.physique + G.additional_physique) * 10 // The one who is grabbing physique
-		var/resist_physique = (physique + additional_physique) * 10 /// The one who is  resisting physique
-        resist_chance = (resist_chance + (resist_physique - grabber_physique))/altered_grab_state
 		var/resist_physique = (physique + additional_physique) * 10 // The one who is  resisting physique
 		resist_chance = ((resist_chance + (resist_physique - grabber_physique))/altered_grab_state)
+		if(prob(resist_chance))
 			visible_message("<span class='danger'>[src] breaks free of [pulledby]'s grip!</span>", \
 							"<span class='danger'>You break free of [pulledby]'s grip!</span>", null, null, pulledby)
 			to_chat(pulledby, "<span class='warning'>[src] breaks free of your grip!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Modified the existing TG Grab system to include the WoD Physique Stat
Example : The one who is grabbing has a Physique Stat of 5, the one Resisting has a Physique Stat of 1
The game has a 60% Base chance to resist, since the different is so high it will be now 60 - (50 - 10), ending up with a 20% chance of escaping the grab, the same way if it is reversed their chances will increase to 100%.

Compiled tested, and tested ingame with logs.

## Why It's Good For The Game

More realistic, now if your physique stat is higher than someone, their chances of resisting are lower, if their physique stat is higher their chances of resisting are higher.

## Changelog
:cl:
add: Physique now contributes to grab mechanics.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
