### PR TITLE
TGMC .vscode selective-port & adding tgs_test/obj & tgs_test/bin to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,5 +194,6 @@ imgui.ini
 config/config.txt
 config/dbconfig.txt
 
-#tgs_test @ tools/tgs_test
-/tools/tgs_test*
+#tgs_test thats generated @ obj & bin
+/tools/tgs_test/obj*
+/tools/tgs_test/bin*

--- a/.gitignore
+++ b/.gitignore
@@ -160,6 +160,9 @@ Temporary Items
 
 #Visual studio stuff
 *.vscode/*
+!/.vscode/extensions.json
+!/.vscode/launch.json
+!/.vscode/tasks.json
 /tools/MapAtmosFixer/MapAtmosFixer/obj/*
 /tools/MapAtmosFixer/MapAtmosFixer/bin/*
 /tools/CreditsTool/bin/*
@@ -190,3 +193,6 @@ Temporary Items
 imgui.ini
 config/config.txt
 config/dbconfig.txt
+
+#tgs_test @ tools/tgs_test
+/tools/tgs_test*

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,15 @@
+{
+	"recommendations": [
+		"arcanis.vscode-zipfs",
+		"dbaeumer.vscode-eslint",
+		"donkie.vscode-tgstation-test-adapter",
+		"stylemistake.auto-comment-blocks",
+		"oderwat.indent-rainbow",
+		"platymuus.dm-langclient",
+		"editorconfig.editorconfig",
+		"eamodio.gitlens",
+		"anturk.dmi-editor",
+		"sukumo28.wav-preview",
+		"esbenp.prettier-vscode"
+	]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"type": "byond",
+			"request": "launch",
+			"name": "Launch DreamSeeker",
+			"preLaunchTask": "Build All",
+			"dmb": "${workspaceFolder}/${command:CurrentDMB}"
+		},
+		{
+			"type": "byond",
+			"request": "launch",
+			"name": "Launch DreamDaemon",
+			"preLaunchTask": "Build All",
+			"dmb": "${workspaceFolder}/${command:CurrentDMB}",
+			"dreamDaemon": true
+		}
+	]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,42 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "process",
+			"command": "tools/build/build",
+			"windows": {
+				"command": ".\\tools\\build\\build.bat"
+			},
+			"options": {
+				"env": {
+					"DM_EXE": "${config:dreammaker.byondPath}"
+				}
+			},
+			"problemMatcher": [
+				"$dreammaker",
+				"$tsc",
+				"$eslint-stylish"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"dependsOn": "dm: reparse",
+			"label": "Build All"
+		},
+		{
+			"type": "dreammaker",
+			"dme": "tgstation.dme",
+			"problemMatcher": [
+				"$dreammaker"
+			],
+			"group": "build",
+			"label": "dm: build - tgstation.dme"
+		},
+		{
+			"command": "${command:dreammaker.reparse}",
+			"group": "build",
+			"label": "dm: reparse"
+		}
+	]
+}


### PR DESCRIPTION
## About The Pull Request
Ports TGMC .vscode files @ [here](https://github.com/tgstation/TerraGov-Marine-Corps/tree/master/.vscode) to make this easier to work with in .vscode

Adds new .vscode files to .gitignore too just in case, oh also adds tools/tgs_test/bin* & tools/tgs_test/obj* to the .gitignore since they keep buggering me in gitkraken even though they're simply user-generated and should otherwise never be commited
## Why It's Good For The Game
Easier coding/development more coding/development better/coding/development, the usual.

## Changelog
Nothing worth putting in the changelog since this will entirely be development-focused and otherwise unseen by players outside of the later ripples that having an easier/more-streamlined development pipeline involves.