### PR TITLE
Adds lighting to the ATM

### DIFF
--- a/code/modules/vtmb/electronics/atms/atm.dm
+++ b/code/modules/vtmb/electronics/atms/atm.dm
@@ -17,6 +17,13 @@
 
 	var/atm_balance = 0
 	var/obj/item/vamp/creditcard/current_card = null
+	light_system = STATIC_LIGHT
+	light_color = COLOR_GREEN
+	light_range = 2
+	light_power = 1
+	light_on = TRUE
+
+
 
 /datum/bank_account
 	var/account_owner = ""


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
Adds green lighting to the ATMs.
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
What it does it makes every ATM emits green light that isn't very strong.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
ATMs tend to hide in the darkness, so it's hard for players to see them or even find them in the first place. This will be helpful for people to find an ATM besides ATMS do emit light anyways.
![atmexample](https://github.com/user-attachments/assets/8062bad4-cdfe-409c-9179-6e367c3f2529)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: added green light to the atm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
