### PR TITLE
Shadow Tentacle Hot Fix

### DIFF
--- a/code/modules/wod13/melee.dm
+++ b/code/modules/wod13/melee.dm
@@ -179,6 +179,7 @@
 	block_chance = 0
 	icon_state = "lasombra"
 	masquerade_violating = TRUE
+	is_iron = FALSE
 
 /obj/item/melee/vampirearms/knife/gangrel/lasombra/afterattack(atom/target, mob/living/carbon/user, proximity)
 	if(!proximity)


### PR DESCRIPTION
## About The Pull Request
Using the shadow tentacles from obtenebration while playing a kiasyd procs their frenzy given the fact their knives, I've added the is_iron flag to them setting it to false

## Why It's Good For The Game
Fixes an overlooked bug 

## Changelog
:cl:
fix: shadow tentacles proccing kiasyd frenzy


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
