### PR TITLE
Gives more clans the keys to their havens

### DIFF
--- a/code/modules/vtmb/vampire_clane/baali.dm
+++ b/code/modules/vtmb/vampire_clane/baali.dm
@@ -11,13 +11,13 @@
 	female_clothes = "/obj/item/clothing/under/vampire/baali/female"
 	enlightenment = TRUE
 	whitelisted = TRUE
+	clan_keys = /obj/item/vamp/keys/baali
 
 /datum/vampireclane/baali/on_gain(mob/living/carbon/human/H)
 	..()
 	H.faction |= "Baali"
 	var/datum/brain_trauma/mild/phobia/security/T = new()
 	H.gain_trauma(T, TRAUMA_RESILIENCE_ABSOLUTE)
-	H.put_in_r_hand(new /obj/item/vamp/keys/baali(H))
 
 /datum/discipline/daimonion/post_gain(mob/living/carbon/human/H)
 	if(level >= 3)

--- a/code/modules/vtmb/vampire_clane/bruja.dm
+++ b/code/modules/vtmb/vampire_clane/bruja.dm
@@ -10,3 +10,4 @@
 	)
 	male_clothes = "/obj/item/clothing/under/vampire/brujah"
 	female_clothes = "/obj/item/clothing/under/vampire/brujah/female"
+	clan_keys = /obj/item/vamp/keys/brujah

--- a/code/modules/vtmb/vampire_clane/clane.dm
+++ b/code/modules/vtmb/vampire_clane/clane.dm
@@ -29,6 +29,7 @@ And it also helps for the character set panel
 	var/accessories = list()
 	var/accessories_layers = list()
 	var/current_accessory
+	var/clan_keys //Keys to your hideout
 
 /datum/vampireclane/proc/on_gain(var/mob/living/carbon/human/H)
 	if(length(accessories))
@@ -115,3 +116,6 @@ And it also helps for the character set panel
 			var/obj/effect/landmark/latejoin_masquerade/LM = pick(GLOB.masquerade_latejoin)
 			if(LM)
 				H.forceMove(LM.loc)
+	if(clan_keys)
+		var/obj/item/vamp/keys/starting_keys = new clan_keys
+		H.put_in_r_hand(new starting_keys(H))

--- a/code/modules/vtmb/vampire_clane/clane.dm
+++ b/code/modules/vtmb/vampire_clane/clane.dm
@@ -117,5 +117,4 @@ And it also helps for the character set panel
 			if(LM)
 				H.forceMove(LM.loc)
 	if(clan_keys)
-		var/obj/item/vamp/keys/starting_keys = new clan_keys
-		H.put_in_r_hand(new starting_keys(H))
+		H.put_in_r_hand(new clan_keys(H))

--- a/code/modules/vtmb/vampire_clane/doc.dm
+++ b/code/modules/vtmb/vampire_clane/doc.dm
@@ -11,6 +11,4 @@
 	female_clothes = "/obj/item/clothing/under/vampire/toreador/female"
 	enlightenment = FALSE
 	whitelisted = TRUE
-
-/datum/vampireclane/doc/post_gain(mob/living/carbon/human/H)
-	H.put_in_r_hand(new /obj/item/vamp/keys/daughters(H))
+	clan_keys = /obj/item/vamp/keys/daughters

--- a/code/modules/vtmb/vampire_clane/malkavian.dm
+++ b/code/modules/vtmb/vampire_clane/malkavian.dm
@@ -9,6 +9,7 @@
 	)
 	male_clothes = "/obj/item/clothing/under/vampire/malkavian"
 	female_clothes = "/obj/item/clothing/under/vampire/malkavian/female"
+	clan_keys = /obj/item/vamp/keys/malkav
 
 /datum/discipline/dementation/post_gain(mob/living/carbon/human/H)
 	..()

--- a/code/modules/vtmb/vampire_clane/nosferatu.dm
+++ b/code/modules/vtmb/vampire_clane/nosferatu.dm
@@ -29,6 +29,7 @@
 	accessories = list("nosferatu_ears")
 	accessories_layers = list("nosferatu_ears" = UPPER_EARS_LAYER)
 	current_accessory = "nosferatu_ears"
+	clan_keys = /obj/item/vamp/keys/nosferatu
 
 /datum/vampireclane/nosferatu/on_gain(mob/living/carbon/human/H)
 	..()

--- a/code/modules/vtmb/vampire_clane/salubri.dm
+++ b/code/modules/vtmb/vampire_clane/salubri.dm
@@ -11,9 +11,7 @@
 	female_clothes = "/obj/item/clothing/under/vampire/salubri/female"
 	enlightenment = FALSE
 	whitelisted = FALSE
-
-/datum/vampireclane/salubri/post_gain(mob/living/carbon/human/H)
-	H.put_in_r_hand(new /obj/item/vamp/keys/salubri(H))
+	clan_keys = /obj/item/vamp/keys/salubri
 
 /datum/discipline/valeren/post_gain(mob/living/carbon/human/H)
 	if(level >= 4)

--- a/code/modules/vtmb/vampire_clane/toreador.dm
+++ b/code/modules/vtmb/vampire_clane/toreador.dm
@@ -10,3 +10,4 @@
 	humanitymod = 2
 	male_clothes = "/obj/item/clothing/under/vampire/toreador"
 	female_clothes = "/obj/item/clothing/under/vampire/toreador/female"
+	clan_keys = /obj/item/vamp/keys/toreador


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives Brujah, Malkavian, Nosferatu and Toreador the keys to their clan havens upon spawning so that they don't have to break in. Slightly changes how this is handled so that instead of it being added to the `post_gain` proc, any clan can have their `clan_key` variable set to make sure they spawn with a certain item.

## Why It's Good For The Game

Not everyone builds for lockpicking, and these areas go underused in part because it's inconvenient to get to them. Nosferatu specifically benefit strongly from having access to the hideout they spawn next to, because of the mask vendor inside. A primogen can potentially let you in, but that's inconsistent at best and (for Nosferatu) rarely seen at worst.

## Changelog
:cl:
tweak: brujah, nosferatu, malkavians, toreador all spawn with the keys to their clan hideout
code: changed how clan keys are spawned behind the scenes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
