### PR TITLE
NPC Slowdown

### DIFF
--- a/code/modules/wod13/npc.dm
+++ b/code/modules/wod13/npc.dm
@@ -37,6 +37,9 @@
 
 	var/list/spotted_bodies = list()
 
+/datum/movespeed_modifier/npc
+	multiplicative_slowdown = 2
+
 /datum/socialrole
 	//For randomizing
 	var/list/s_tones = list("albino",

--- a/code/modules/wod13/npc_movement.dm
+++ b/code/modules/wod13/npc_movement.dm
@@ -32,6 +32,7 @@
 /mob/living/carbon/human/npc/Initialize()
 	..()
 	GLOB.npc_list += src
+	add_movespeed_modifier(/datum/movespeed_modifier/npc)
 
 /mob/living/carbon/human/npc/death()
 	walk(src,0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gotta go... not so fast. This is a minor edit that should make the NPCs move significantly slower. You can even catch up to them without being Usain Bolt! Truly, they seem like they didn't just miss their train and are out on some late night business.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
NPCs shouldn't be faster than players, or super fast as they were in general. What was up with that anyway?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked NPC walkspeed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
