### PR TITLE
Rebalance to gangrel claws

### DIFF
--- a/code/modules/wod13/melee.dm
+++ b/code/modules/wod13/melee.dm
@@ -336,7 +336,9 @@
 		return
 	if(isliving(target))
 		var/mob/living/L = target
-		L.apply_damage(30, CLONE)
+		L.apply_damage(10, CLONE)
+		L.apply_damage(10, BURN)
+		L.apply_damage(10, BRUTE)
 
 /obj/item/melee/vampirearms/knife/gangrel/lasombra
 	name = "shadow tentacle"


### PR DESCRIPTION
## About The Pull Request
Damage for the claws has been spread out accordingly to not solely be clone damage

## Why It's Good For The Game
It rebalances the flat clone damage done by protean claws, and puts ten into brute, burn and clone. Making them less taxing in general to fight but still providing enough fear for vampires and werewolves when going up against a gangrel

## Changelog
:cl:
balance: rebalanced something


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
