### PR TITLE
Primogen showing on your about me, suggestion: Tunnel Walrus

### DIFF
--- a/code/modules/vtmb/kindred_species.dm
+++ b/code/modules/vtmb/kindred_species.dm
@@ -137,19 +137,24 @@
 
 		if(host.clane.name == "Brujah")
 			if(GLOB.brujahname != "")
-				dat += " My primogen is:  [GLOB.brujahname].<BR>"
+				if(host.real_name != GLOB.brujahname)
+					dat += " My primogen is:  [GLOB.brujahname].<BR>"
 		if(host.clane.name == "Malkavian")
 			if(GLOB.malkavianname != "")
-				dat += " My primogen is:  [GLOB.malkavianname].<BR>"
+				if(host.real_name != GLOB.malkavianname)
+					dat += " My primogen is:  [GLOB.malkavianname].<BR>"
 		if(host.clane.name == "Nosferatu")
 			if(GLOB.nosferatuname != "")
-				dat += " My primogen is:  [GLOB.nosferatuname].<BR>"
+				if(host.real_name != GLOB.nosferatuname)
+					dat += " My primogen is:  [GLOB.nosferatuname].<BR>"
 		if(host.clane.name == "Toreador")
 			if(GLOB.toreadorname != "")
-				dat += " My primogen is:  [GLOB.toreadorname].<BR>"
+				if(host.real_name != GLOB.toreadorname)
+					dat += " My primogen is:  [GLOB.toreadorname].<BR>"
 		if(host.clane.name == "Ventrue")
 			if(GLOB.ventruename != "")
-				dat += " My primogen is:  [GLOB.ventruename].<BR>"
+				if(host.real_name != GLOB.ventruename)
+					dat += " My primogen is:  [GLOB.ventruename].<BR>"
 
 		dat += "<b>Physique</b>: [host.physique]<BR>"
 		dat += "<b>Dexterity</b>: [host.dexterity]<BR>"

--- a/code/modules/vtmb/kindred_species.dm
+++ b/code/modules/vtmb/kindred_species.dm
@@ -134,6 +134,23 @@
 					humanity = "I'm losing control over my beast!"
 
 		dat += "[humanity]<BR>"
+
+		if(host.clane.name == "Brujah")
+			if(GLOB.brujahname != "")
+				dat += " My primogen is:  [GLOB.brujahname] .<BR>"
+		if(host.clane.name == "Malkavian")
+			if(GLOB.malkavianname != "")
+				dat += " My primogen is:  [GLOB.malkavianname] .<BR>"
+		if(host.clane.name == "Nosferatu")
+			if(GLOB.nosferatuname != "")
+				dat += " My primogen is:  [GLOB.nosferatuname] .<BR>"
+		if(host.clane.name == "Toreador")
+			if(GLOB.toreadorname != "")
+				dat += " My primogen is:  [GLOB.toreadorname] .<BR>"
+		if(host.clane.name == "Ventrue")
+			if(GLOB.ventruename != "")
+				dat += " My primogen is:  [GLOB.ventruename] .<BR>"
+
 		dat += "<b>Physique</b>: [host.physique]<BR>"
 		dat += "<b>Dexterity</b>: [host.dexterity]<BR>"
 		dat += "<b>Social</b>: [host.social]<BR>"

--- a/code/modules/vtmb/kindred_species.dm
+++ b/code/modules/vtmb/kindred_species.dm
@@ -137,19 +137,19 @@
 
 		if(host.clane.name == "Brujah")
 			if(GLOB.brujahname != "")
-				dat += " My primogen is:  [GLOB.brujahname] .<BR>"
+				dat += " My primogen is:  [GLOB.brujahname].<BR>"
 		if(host.clane.name == "Malkavian")
 			if(GLOB.malkavianname != "")
-				dat += " My primogen is:  [GLOB.malkavianname] .<BR>"
+				dat += " My primogen is:  [GLOB.malkavianname].<BR>"
 		if(host.clane.name == "Nosferatu")
 			if(GLOB.nosferatuname != "")
-				dat += " My primogen is:  [GLOB.nosferatuname] .<BR>"
+				dat += " My primogen is:  [GLOB.nosferatuname].<BR>"
 		if(host.clane.name == "Toreador")
 			if(GLOB.toreadorname != "")
-				dat += " My primogen is:  [GLOB.toreadorname] .<BR>"
+				dat += " My primogen is:  [GLOB.toreadorname].<BR>"
 		if(host.clane.name == "Ventrue")
 			if(GLOB.ventruename != "")
-				dat += " My primogen is:  [GLOB.ventruename] .<BR>"
+				dat += " My primogen is:  [GLOB.ventruename].<BR>"
 
 		dat += "<b>Physique</b>: [host.physique]<BR>"
 		dat += "<b>Dexterity</b>: [host.dexterity]<BR>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Based on the Tunnel Walrus suggestion, now if you got a primogen it will show on your about me, there are only 5 primogen roles at the moment.

## Why It's Good For The Game

Basically as the suggestion states, you should know your primogen and the about me is a good place to have that information.

## Changelog
:cl:
add: If there is a primogen for your clan, they will show up on your about me.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
