### PR TITLE
Adds old clan tzimisce up to be whitelisted

### DIFF
--- a/code/modules/vtmb/vampire_clane/old_clan_tzimisce.dm
+++ b/code/modules/vtmb/vampire_clane/old_clan_tzimisce.dm
@@ -13,7 +13,7 @@
 	enlightenment = TRUE
 	var/obj/item/heirl
 	restricted_disciplines = list(/datum/discipline/vicissitude)
-	whitelisted = FALSE
+	whitelisted = TRUE
 
 /datum/vampireclane/old_clan_tzimisce/post_gain(mob/living/carbon/human/H)
 	..()


### PR DESCRIPTION
## About The Pull Request

This seems to be an oversight but one that really should be fixed. In numerous incidents I've witnessed, I've seen old clan tzimisce be complete and utter shitters with their OP armor with the most lore breaking names imaginable. This fixes it.

## Why It's Good For The Game

One of the main things is that Old Clan are kind of rare, and they get stupidly good armor which they use on a consistent basis to morb out.

## Changelog
:cl:
tweaks: Makes old clan tzimisce whitelisted
/:cl: