### PR TITLE
Normalises XP rates a little

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -250,10 +250,10 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 					if(H.key)
 						var/datum/preferences/P = GLOB.preferences_datums[ckey(H.key)]
 						if(P)
-							P.add_experience(1)
+							P.add_experience(2)
 							if(H.mind)
 								if("[H.mind.assigned_role]" == "Prince" || "[H.mind.assigned_role]" == "Sheriff" || "[H.mind.assigned_role]" == "Scourge" ||  "[H.mind.assigned_role]" == "Seneschal" || "[H.mind.assigned_role]" == "Chantry Regent" || "[H.mind.assigned_role]" == "Baron" || "[H.mind.assigned_role]" == "Dealer")
-									P.add_experience(3)
+									P.add_experience(2)
 							if(won)
 								if(H.vampire_faction == won)
 									P.add_experience(1)
@@ -262,9 +262,9 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 							var/toreador_bonus = 0
 							if(iskindred(H) && H.clane)
 								if(H.clane.name == "Toreador")
-									toreador_bonus = 2
+									toreador_bonus = 1
 							if(H.total_erp > 9000)
-								P.add_experience(1+toreador_bonus)
+								P.add_experience(2+toreador_bonus)
 							if(H.total_cleaned > 25)
 								P.add_experience(1)
 							if(H.mind)

--- a/code/controllers/subsystem/city_time.dm
+++ b/code/controllers/subsystem/city_time.dm
@@ -51,10 +51,10 @@ SUBSYSTEM_DEF(city_time)
 					if(H.key)
 						var/datum/preferences/P = GLOB.preferences_datums[ckey(H.key)]
 						if(P)
-							P.add_experience(1)
+							P.add_experience(2)
 							if(H.mind)
 								if("[H.mind.assigned_role]" == "Prince" || "[H.mind.assigned_role]" == "Sheriff" || "[H.mind.assigned_role]" == "Seneschal" || "[H.mind.assigned_role]" == "Chantry Regent" || "[H.mind.assigned_role]" == "Baron" || "[H.mind.assigned_role]" == "Dealer")
-									P.add_experience(3)
+									P.add_experience(2)
 							if(!HAS_TRAIT(H, TRAIT_NON_INT))
 								if(won)
 									if(H.vampire_faction == won)
@@ -65,9 +65,9 @@ SUBSYSTEM_DEF(city_time)
 								var/toreador_bonus = 0
 								if(iskindred(H) && H.clane)
 									if(H.clane.name == "Toreador")
-										toreador_bonus = 2
+										toreador_bonus = 1
 								if(H.total_erp > 1500)
-									P.add_experience(1+toreador_bonus)
+									P.add_experience(2+toreador_bonus)
 									H.total_erp = 0
 								if(H.total_cleaned > 25)
 									P.add_experience(1)
@@ -100,10 +100,10 @@ SUBSYSTEM_DEF(city_time)
 					if(H.key)
 						var/datum/preferences/P = GLOB.preferences_datums[ckey(H.key)]
 						if(P)
-							P.add_experience(1)
+							P.add_experience(2)
 							if(H.mind)
 								if("[H.mind.assigned_role]" == "Prince" || "[H.mind.assigned_role]" == "Sheriff" || "[H.mind.assigned_role]" == "Seneschal" || "[H.mind.assigned_role]" == "Chantry Regent" || "[H.mind.assigned_role]" == "Baron" || "[H.mind.assigned_role]" == "Dealer")
-									P.add_experience(3)
+									P.add_experience(2)
 							if(!HAS_TRAIT(H, TRAIT_NON_INT))
 								if(won)
 									if(H.vampire_faction == won)
@@ -114,9 +114,9 @@ SUBSYSTEM_DEF(city_time)
 								var/toreador_bonus = 0
 								if(iskindred(H) && H.clane)
 									if(H.clane.name == "Toreador")
-										toreador_bonus = 2
+										toreador_bonus = 1
 								if(H.total_erp > 9000)
-									P.add_experience(1+toreador_bonus)
+									P.add_experience(2+toreador_bonus)
 									H.total_erp = 0
 								if(H.total_cleaned > 25)
 									P.add_experience(1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The basic rate of XP per-XP-check (when the game checks for social, cleaning and base XP) is now 2, not 1, and leadership roles (i.e. baron, sheriff, dealer) now get +2 XP rather than +3. Social XP is up by 1 across the board to 2 per check, and the Toreador bonus has been lowered to 1 from 2. 
In other words: Toreador kindred and leadership roles will get the same amount of XP, but anyone else will be a little closer to the frankly-disproportionate XP rates (a Toreador Seneschal getting 21 XP when someone doing the same amount of RP would get **6**).

## Why It's Good For The Game

"Won't this hasten ~~Gehenna~~ the elderpocalypse by giving out more XP and letting people become super-powerful now?"
Not really. Someone who really wants to grind XP can do that with relative ease already, and this doesn't make it any easier for them. But equalising other rates _up_ avoids encouraging people to jump into roles they're not ready for and play a plan they're not interested in to progress at a rate that feels meaningful.

## Changelog
:cl:
tweak: base xp per round is now 6, +6 over the whole round for leadership roles. this is a baseline increase and makes no difference to roles that get extra xp
tweak: social xp is now 2 per shot, with the toreador bonus decreased by 1. this is a baseline increase and makes no difference to toreador characters.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
