### PR TITLE
Fixes Tzim upgrade stacking + Misc tweaks

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -351,6 +351,7 @@
 	melee_damage_lower = 15
 	melee_damage_upper = 30
 	speed = -0.1
+	dodging = TRUE
 
 /mob/living/simple_animal/hostile/beastmaster/cat/Initialize()
 	. = ..()

--- a/code/modules/vtmb/vampire_clane/tzimisce.dm
+++ b/code/modules/vtmb/vampire_clane/tzimisce.dm
@@ -24,8 +24,8 @@
 /obj/effect/proc_holder/spell/targeted/shapeshift/tzimisce
 	name = "Tzimisce Form"
 	desc = "Take on the shape a beast."
-	charge_max = 50
-	cooldown_min = 50
+	charge_max = 100
+	cooldown_min = 100
 	revert_on_death = TRUE
 	die_with_shapeshifted_form = FALSE
 	shapeshift_type = /mob/living/simple_animal/hostile/tzimisce_beast
@@ -95,8 +95,8 @@
 	spawn(200)
 		if(TE)
 			TE.Restore(TE.myshape)
-			NG.Stun(15)
-			NG.do_jitter_animation(30)
+			NG.Stun(2 SECONDS)
+			NG.do_jitter_animation(5 SECONDS)
 
 /datum/action/basic_vicissitude
 	name = "Vicissitude Upgrades"
@@ -117,6 +117,8 @@
 	if(upgrade)
 //		if(H.clane)
 //			H.clane.violating_appearance = TRUE
+		if(used)
+			return
 		used = TRUE
 		ADD_TRAIT(H, TRAIT_NONMASQUERADE, TRAUMA_TRAIT)
 		switch(upgrade)
@@ -126,8 +128,8 @@
 				H.skin_tone = "albino"
 				H.hairstyle = "Bald"
 				H.base_body_mod = ""
-				H.physiology.armor.melee = H.physiology.armor.melee+50
-				H.physiology.armor.bullet = H.physiology.armor.bullet+50
+				H.physiology.armor.melee = H.physiology.armor.melee+20
+				H.physiology.armor.bullet = H.physiology.armor.bullet+20
 				H.update_body()
 				H.update_body_parts()
 				H.update_hair()
@@ -375,7 +377,7 @@
 	var/furry_changed = FALSE
 
 /datum/movespeed_modifier/centipede
-	multiplicative_slowdown = -1
+	multiplicative_slowdown = -0.6
 
 /mob/living/simple_animal/hostile/bloodcrawler
 	var/collected_blood = 0
@@ -565,7 +567,7 @@
 /datum/crafting_recipe/tzi_biter
 	name = "Biting Abomination"
 	time = 100
-	reqs = list(/obj/item/stack/human_flesh = 5, /obj/item/bodypart/r_arm = 2, /obj/item/bodypart/l_arm = 2, /obj/item/spine = 1)
+	reqs = list(/obj/item/stack/human_flesh = 2, /obj/item/bodypart/r_arm = 2, /obj/item/bodypart/l_arm = 2, /obj/item/spine = 1)
 	result = /mob/living/simple_animal/hostile/biter
 	always_available = FALSE
 	category = CAT_TZIMISCE
@@ -573,7 +575,7 @@
 /datum/crafting_recipe/tzi_fister
 	name = "Punching Abomination"
 	time = 100
-	reqs = list(/obj/item/stack/human_flesh = 10, /obj/item/bodypart/r_arm = 1, /obj/item/bodypart/l_arm = 1, /obj/item/spine = 1, /obj/item/guts = 1)
+	reqs = list(/obj/item/stack/human_flesh = 4, /obj/item/bodypart/r_arm = 1, /obj/item/bodypart/l_arm = 1, /obj/item/spine = 1, /obj/item/guts = 1)
 	result = /mob/living/simple_animal/hostile/fister
 	always_available = FALSE
 	category = CAT_TZIMISCE
@@ -581,7 +583,7 @@
 /datum/crafting_recipe/tzi_tanker
 	name = "Fat Abomination"
 	time = 100
-	reqs = list(/obj/item/stack/human_flesh = 15, /obj/item/bodypart/r_arm = 1, /obj/item/bodypart/l_arm = 1, /obj/item/bodypart/r_leg = 1, /obj/item/bodypart/l_leg = 1, /obj/item/spine = 1, /obj/item/guts = 5)
+	reqs = list(/obj/item/stack/human_flesh = 8, /obj/item/bodypart/r_arm = 1, /obj/item/bodypart/l_arm = 1, /obj/item/bodypart/r_leg = 1, /obj/item/bodypart/l_leg = 1, /obj/item/spine = 1, /obj/item/guts = 2)
 	result = /mob/living/simple_animal/hostile/tanker
 	always_available = FALSE
 	category = CAT_TZIMISCE
@@ -603,8 +605,8 @@
 	response_disarm_simple = "gently push aside"
 	emote_taunt = list("gnashes")
 	speed = -1
-	maxHealth = 25
-	health = 25
+	maxHealth = 75
+	health = 75
 
 	harm_intent_damage = 8
 	obj_damage = 50
@@ -653,8 +655,8 @@
 	icon_dead = "fister_dead"
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
 	speak_chance = 0
-	maxHealth = 50
-	health = 50
+	maxHealth = 100
+	health = 100
 	butcher_results = list(/obj/item/stack/human_flesh = 10)
 	harm_intent_damage = 5
 	melee_damage_lower = 25
@@ -705,9 +707,9 @@
 	icon_living = "gangrel_f"
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
 	speak_chance = 0
-	speed = -0.5
-	maxHealth = 300
-	health = 300
+	speed = -0.4
+	maxHealth = 400
+	health = 400
 	butcher_results = list(/obj/item/stack/human_flesh = 20)
 	harm_intent_damage = 5
 	melee_damage_lower = 40
@@ -729,7 +731,7 @@
 	health = 500
 	melee_damage_lower = 45
 	melee_damage_upper = 45
-	speed = -0.8
+	speed = -0.6
 
 /mob/living/simple_animal/hostile/gangrel/best
 	icon_state = "gangrel_m"
@@ -738,7 +740,7 @@
 	health = 600
 	melee_damage_lower = 55
 	melee_damage_upper = 55
-	speed = -1
+	speed = -0.8
 
 /mob/living/simple_animal/hostile/gargoyle
 	name = "Gargoyle"
@@ -749,12 +751,12 @@
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
 	speak_chance = 0
 	speed = -1
-	maxHealth = 300
-	health = 300
+	maxHealth = 400
+	health = 400
 	butcher_results = list(/obj/item/stack/human_flesh = 20)
 	harm_intent_damage = 5
-	melee_damage_lower = 30
-	melee_damage_upper = 30
+	melee_damage_lower = 25
+	melee_damage_upper = 45
 	attack_verb_continuous = "punches"
 	attack_verb_simple = "punch"
 	attack_sound = 'sound/weapons/punch1.ogg'
@@ -811,12 +813,12 @@
 	pixel_z = -16
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
 	speak_chance = 0
-	speed = -1
+	speed = -0.55
 	maxHealth = 575
 	health = 575
 	butcher_results = list(/obj/item/stack/human_flesh = 20)
 	harm_intent_damage = 5
-	melee_damage_lower = 70
+	melee_damage_lower = 35
 	melee_damage_upper = 70
 	attack_verb_continuous = "slashes"
 	attack_verb_simple = "slash"
@@ -841,8 +843,8 @@
 	health = 100
 	butcher_results = list(/obj/item/stack/human_flesh = 20)
 	harm_intent_damage = 5
-	melee_damage_lower = 1
-	melee_damage_upper = 1
+	melee_damage_lower = 10
+	melee_damage_upper = 10
 	attack_verb_continuous = "slashes"
 	attack_verb_simple = "slash"
 	attack_sound = 'sound/weapons/slash.ogg'

--- a/code/modules/wod13/npcroles.dm
+++ b/code/modules/wod13/npcroles.dm
@@ -868,9 +868,10 @@
 	maxHealth = 20
 	health = 20
 	harm_intent_damage = 10
-	melee_damage_lower = 10
+	melee_damage_lower = 5
 	melee_damage_upper = 10
 	speed = 0
+	dodging = TRUE
 
 /mob/living/simple_animal/hostile/beastmaster/rat/Initialize()
 	. = ..()
@@ -885,14 +886,16 @@
 	name = "bat"
 	desc = "It's a bat."
 	is_flying_animal = TRUE
-	speed = -1
+	maxHealth = 10
+	health = 10
+	speed = -0.8
 
 /mob/living/simple_animal/hostile/beastmaster/rat/flying/UnarmedAttack(atom/A)
 	. = ..()
 	if(ishuman(A))
 		var/mob/living/carbon/human/H = A
 		if(H.bloodpool)
-			if(prob(25))
+			if(prob(10))
 				H.bloodpool = max(0, H.bloodpool-1)
 				beastmaster.bloodpool = min(beastmaster.maxbloodpool, beastmaster.bloodpool+1)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Tzim can only have one upgrade as the Elder intended.
Skin armour upgrade changed to a more reasonable value when factoring in worn armour etc.
Nerfs bats, buffs rats and cats.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Destroys the patented REALB kills half the server with armour stacking and wings meta.
The villain becomes the hero who gets broken things fixed??

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked my neck doing these changes
balance: I balance on a razor's edge of balance
fix: the issue
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
