### PR TITLE
Fix Malkavians not getting their keys.

### DIFF
--- a/code/modules/vtmb/vampire_clane/malkavian.dm
+++ b/code/modules/vtmb/vampire_clane/malkavian.dm
@@ -12,6 +12,7 @@
 	clan_keys = /obj/item/vamp/keys/malkav
 
 /datum/vampireclane/malkavian/post_gain(mob/living/carbon/human/H)
+	..()
 	var/datum/action/cooldown/malk_hivemind/GH = new()
 	GH.Grant(H)
 	GLOB.malkavian_list += H


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

[Compiled tested and tested ingame]

Previously malkavian did not spawned with their clan keys unlike the others clans with a primogen, it was not really an issue with the code just that who made the malkavian post gain proc forgot to put the "..()" so it was not inheriting the clan.dm proc and just overwriting with their own.

Le keys:
![image](https://github.com/user-attachments/assets/84921bf2-8ef3-4c56-a7dd-7f0c749dce11)


## Why It's Good For The Game

Fix!

## Changelog
:cl:
fix: Fix malkavians not getting their hideout keys.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
