### PR TITLE
Fix Saulocept artefact giving no xp bonus 

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -275,6 +275,8 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 									var/datum/antagonist/A = H.mind.special_role
 									if(A.check_completed())
 										P.add_experience(3)
+							if(H.experience_plus == 10)
+								P.add_experience(10)
 							P.save_preferences()
 							P.save_character()
 	var/old_runlevel = current_runlevel


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

[Compiled tested and tested ingame]

I was going to make a new var for it but since the only way to get the experience_plus is from the artefact i left the check using the same var, now if you have it on your inventory you will get the experience_plus and at the end of the round if you still have it the xp will be added to your char.

## Why It's Good For The Game

Fix!

## Changelog
:cl:
Fix: Saulocept does something now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
