### PR TITLE
Fix Ghoul aura oversights

### DIFF
--- a/code/modules/wod13/witness.dm
+++ b/code/modules/wod13/witness.dm
@@ -62,15 +62,22 @@
 		var/ghoul = FALSE
 		if(isghoul(src))
 			//Pale spots in the aura, had to be done manually since holder.color will show only a type of color
+			holder.overlays = null 
+			holder.color = null
 			holder.icon_state = "aura_ghoul"
 			ghoul = TRUE
 
 		if(isnpc(src))
 			var/mob/living/carbon/human/npc/N = src
-			if(N.danger_source)
+			if(N.danger_source && !isghoul(N))
 				holder.color = "#ff0000"
-			else
+			else if(!isghoul(N))
 				holder.color = "#0000ff"
+			else if (isghoul(N))
+				holder.overlays = null 
+				holder.color = null
+				holder.icon_state = "aura_ghoul"
+				
 		else if(!ghoul)
 		//Ghoul got a mix of two different colors on the dmi, so it can't recieve any holder.color 
 			if(a_intent == INTENT_HARM)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

i aimed to fix two oversights that i don't checked on the Ghoul aura PR, now if you are a human that is transformed into a ghoul your aura will now be ghoul aura(holder.color and overlays were making it still be blue)
If a vampire transform an npc in a ghoul and a player accept as well, even if they are harm intent their aura won't be black-red anymore, it will become a normal ghoul aura.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Turned ghouls mid round aura is now ghoul aura
fix: Turning npcs into ghouls will always give them ghoul aura (they only become a ghoul if a ghost accepts)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
