### PR TITLE
Fixes anti-masquerade exploit

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -288,14 +288,16 @@
 		if(usr == src)
 			return
 		if(dna)
-			var/no_vote = FALSE
 			for(var/i in H.voted_for)
 				if(i == dna.real_name)
-					no_vote = TRUE
-			if(no_vote)
-				return
+					to_chat(H, "<span class='warning'>You have already noted their masquerade breach! Wait some time until you do that again.</span>")
+					return
 			var/reason = input(usr, "Write a description of violation:", "Spot a Masquerade violation") as text|null
 			if(reason)
+				for(var/i in H.voted_for) //Rudimentary check to avoid queueing a whole bunch of reason texts and then nuking their masquerade to 0.
+					if(i == dna.real_name)
+						to_chat(H, "<span class='warning'>You have already noted their masquerade breach! Wait some time until you do that again.</span>")
+						return
 				reason = trim(copytext_char(sanitize(reason), 1, MAX_MESSAGE_LEN))
 				masquerade_votes++
 				message_admins("[ADMIN_LOOKUPFLW(H)] spotted [ADMIN_LOOKUPFLW(src)]'s Masquerade violation. Description: [reason]")


### PR DESCRIPTION
The exploit hinges on the ability to repeatedly click on the "spot masquerade violation" button and then filling them out one after another, bypassing the usual limitation on reporting a masquerade violation.
This PR fixes it.
Also adds feedback that messages the user in regards to whether they have already spotted the breach.

## Changelog
:cl:
fix: Fixed "Masquerade Blast" exploit by adding a secondary check for whether a player has already spotted a target's masquerade breach.
tweak: Attempting to spot a masquerade breach while already having spotted it will now display a feedback message.
/:cl: