### PR TITLE
Fixes car lockpicking

### DIFF
--- a/code/modules/wod13/car.dm
+++ b/code/modules/wod13/car.dm
@@ -202,20 +202,17 @@ SUBSYSTEM_DEF(carpool)
 				repairing = TRUE
 				if(do_mob(user, src, 20 SECONDS))
 					var/roll = rand(1, 20) + (user.lockpicking+user.dexterity) - 8
+					//(<= 1, break lockpick) (2-9, trigger car alarm), (>= 10, unlock car)
 					if (roll <= 1)
 						to_chat(user, "<span class='warning'>Your lockpick broke!</span>")
 						qdel(K)
 						repairing = FALSE
-					if (roll >= 10)
+						return
+					else if (roll >= 10)
 						locked = FALSE
 						repairing = FALSE
 						to_chat(user, "<span class='notice'>You've managed to open [src]'s lock.</span>")
 						playsound(src, 'code/modules/wod13/sounds/open.ogg', 50, TRUE)
-					if(initial(access) == "none")
-						if(ishuman(user))
-							var/mob/living/carbon/human/H = user
-							H.AdjustHumanity(-1, 6)
-						return
 					else
 						to_chat(user, "<span class='warning'>You've failed to open [src]'s lock.</span>")
 						playsound(src, 'code/modules/wod13/sounds/signal.ogg', 50, FALSE)
@@ -223,6 +220,11 @@ SUBSYSTEM_DEF(carpool)
 							if(P)
 								P.Aggro(user)
 						repairing = FALSE
+						return //Don't penalize vampire humanity if they failed.
+					if(initial(access) == "none") //Stealing a car with no keys assigned to it is basically robbing a random person and not an organization
+						if(ishuman(user))
+							var/mob/living/carbon/human/H = user
+							H.AdjustHumanity(-1, 6)
 						return
 				else
 					to_chat(user, "<span class='warning'>You've failed to open [src]'s lock.</span>")


### PR DESCRIPTION
The issue is that if a car with no access requirements (therefore designated as unowned cars, as the only way to be able to drive them is by hijacking them) was lockpicked then whenever it would trigger an alarm it would instead break and do nothing, blocking the car from being repaired because the "repaired" variable would never be disabled.
If the car was owned (as in, there are keys for it somewhere) then it would always launch an alarm, no matter if the lockpick broke or the user successfully broke in, which was unintended.
This PR fixes it so that it behaves normally again.
Comes with a tiny change/bugfix that prevents humanity loss if the lockpick broke, because humanity loss does not happen upon triggering the car's alarm.
## Changelog
:cl:
fix: Cars that cannot be unlocked by any key will no longer have a likely chance of becoming non-functional bricks when lockpicked.
fix: Cars that can be unlocked by certain keys will no longer always trigger their car alarm.
tweak: Kindred will no longer suffer humanity loss if their lockpick breaks while attempting to unlock a car.
/:cl: