### PR TITLE
Window climbing improvements

### DIFF
--- a/code/datums/elements/climbable.dm
+++ b/code/datums/elements/climbable.dm
@@ -34,6 +34,9 @@
 		examine_texts += "<span class='notice'>[source] looks climbable</span>"
 
 /datum/element/climbable/proc/can_climb(atom/source, mob/user)
+	if(get_turf(user) == get_turf(source))
+		to_chat(user, "<span class='warning'>You are already on \the [source]!</span>")
+		return FALSE
 	return TRUE
 
 /datum/element/climbable/proc/attack_hand(atom/climbed_thing, mob/user)
@@ -79,8 +82,13 @@
 
 /datum/element/climbable/proc/do_climb(atom/climbed_thing, mob/living/user)
 	climbed_thing.density = FALSE
-	. = step(user, get_dir(user,climbed_thing.loc))
+	//Switched from step() to Move() because it allows for diagonal movement
+	//Switched from loc to get_turf() because it is possible to climb through low walls, whose loc variable is the area they're in
+	user.Move(get_turf(climbed_thing))
 	climbed_thing.density = TRUE
+	if(get_turf(user) == get_turf(climbed_thing))
+		return TRUE
+	return FALSE
 
 ///Handles climbing onto the atom when you click-drag
 /datum/element/climbable/proc/mousedrop_receive(atom/climbed_thing, atom/movable/dropped_atom, mob/user)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -106,6 +106,11 @@
 		return TRUE
 	if(locate(/obj/structure/table) in get_turf(mover))
 		return TRUE
+	//Roughly the same elevation
+	if(istype(mover.loc, /turf/closed/wall/vampwall)) //Because "low" type walls aren't standardized and are subtypes of different wall types
+		var/turf/closed/wall/vampwall/vw = mover.loc
+		if(vw.low)
+			return TRUE
 
 /obj/structure/table/CanAStarPass(ID, dir, caller)
 	. = !density

--- a/code/modules/wod13/wallcode.dm
+++ b/code/modules/wod13/wallcode.dm
@@ -54,6 +54,13 @@
 			return
 		if(istype(mover) && (mover.pass_flags & PASSTABLE))
 			return TRUE
+		if(istype(mover.loc, /turf/closed/wall/vampwall)) //Because "low" type walls aren't standardized and are subtypes of different wall types
+			var/turf/closed/wall/vampwall/vw = mover.loc
+			if(vw.low)
+				return TRUE
+		//Roughly the same elevation
+		if(locate(/obj/structure/table) in get_turf(mover))
+			return TRUE
 
 /turf/closed/wall/vampwall/attackby(obj/item/W, mob/user, params)
 	return
@@ -126,6 +133,7 @@
 	icon = 'code/modules/wod13/lowwalls.dmi'
 	opacity = FALSE
 	low = TRUE
+	blocks_air = FALSE //Let the windows block the air transfer
 
 /turf/closed/wall/vampwall/low/window
 	icon_state = "wall-window"
@@ -141,6 +149,7 @@
 	icon = 'code/modules/wod13/lowwalls.dmi'
 	opacity = FALSE
 	low = TRUE
+	blocks_air = FALSE
 
 /turf/closed/wall/vampwall/rich/low/window
 	icon_state = "rich-window"
@@ -160,6 +169,7 @@
 	icon = 'code/modules/wod13/lowwalls.dmi'
 	opacity = FALSE
 	low = TRUE
+	blocks_air = FALSE
 
 /turf/closed/wall/vampwall/junk/low/window
 	icon_state = "junk-window"
@@ -173,6 +183,7 @@
 	icon = 'code/modules/wod13/lowwalls.dmi'
 	opacity = FALSE
 	low = TRUE
+	blocks_air = FALSE
 
 /turf/closed/wall/vampwall/junk/alt/low/window
 	icon_state = "junkalt-window"
@@ -188,6 +199,7 @@
 	icon = 'code/modules/wod13/lowwalls.dmi'
 	opacity = FALSE
 	low = TRUE
+	blocks_air = FALSE
 
 /turf/closed/wall/vampwall/market/low/window
 	icon_state = "market-window"
@@ -207,6 +219,7 @@
 	icon = 'code/modules/wod13/lowwalls.dmi'
 	opacity = FALSE
 	low = TRUE
+	blocks_air = FALSE
 
 /turf/closed/wall/vampwall/old/low/window
 	icon_state = "old-window"
@@ -226,6 +239,7 @@
 	icon = 'code/modules/wod13/lowwalls.dmi'
 	opacity = FALSE
 	low = TRUE
+	blocks_air = FALSE
 
 /turf/closed/wall/vampwall/painted/low/window
 	icon_state = "painted-window"
@@ -245,6 +259,7 @@
 	icon = 'code/modules/wod13/lowwalls.dmi'
 	opacity = FALSE
 	low = TRUE
+	blocks_air = FALSE
 
 /turf/closed/wall/vampwall/rich/old/low/window
 	icon_state = "theater-window"
@@ -264,6 +279,7 @@
 	icon = 'code/modules/wod13/lowwalls.dmi'
 	opacity = FALSE
 	low = TRUE
+	blocks_air = FALSE
 
 /turf/closed/wall/vampwall/brick/low/window
 	icon_state = "brick-window"
@@ -285,6 +301,7 @@
 	icon = 'code/modules/wod13/lowwalls.dmi'
 	opacity = FALSE
 	low = TRUE
+	blocks_air = FALSE
 
 /turf/closed/wall/vampwall/city/low/window
 	icon_state = "city-window"
@@ -325,6 +342,7 @@
 	icon = 'code/modules/wod13/lowwalls.dmi'
 	opacity = FALSE
 	low = TRUE
+	blocks_air = FALSE
 
 /turf/closed/wall/vampwall/bar/low/window
 	icon_state = "bar-window"
@@ -340,6 +358,7 @@
 	icon = 'code/modules/wod13/lowwalls.dmi'
 	opacity = FALSE
 	low = TRUE
+	blocks_air = FALSE
 
 /turf/closed/wall/vampwall/wood/low/window
 	icon_state = "wood-window"


### PR DESCRIPTION
This took way longer than it should have.

- Fixed a bug where it was impossible to climb through low wall windows because a wall's loc is the area it is in and not itself.
- Step() was awkward, and it was replaced with Move(), which also allows for climbing low walls diagonally.
- If you climbed on a low wall then you can move to adjacent low walls and tables, and vice versa.
- Prevented players from climbing something they're already on.
- Fixed a bug where low walls blocked air movement even when they shouldn't. This meant that a character could suffocate while on a low wall.

No changelog because the changelog system doesn't work yet.