### PR TITLE
Fix the chance that being embraced by a violating appearance clan to spawn you in the nosferatu town

### DIFF
--- a/code/modules/vtmb/vampire_clane/clane.dm
+++ b/code/modules/vtmb/vampire_clane/clane.dm
@@ -115,7 +115,7 @@ And it also helps for the character set panel
 							need_lover = FALSE
 
 /datum/vampireclane/proc/post_gain(var/mob/living/carbon/human/H)
-	if(violating_appearance)
+	if(violating_appearance && H.roundstart_vampire)
 		if(length(GLOB.masquerade_latejoin))
 			var/obj/effect/landmark/latejoin_masquerade/LM = pick(GLOB.masquerade_latejoin)
 			if(LM)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It was reported to me that somehow being embraced by a nosferatu could trigger the embraced being tped to the nosferatu town, i tried replicating that on my debug server and was unsucessful but there are indeed some bugs that don't happen on the debug and that could be one of those.
When a vampire joins the game their roundstart_vampire is set to true, it is set to =  false for non vampires and it is set to false too when someone is embraced, now it checks if someone was embraced mid round  and if they were, they can't trigger the tp proc.


## Why It's Good For The Game

Fix
## Changelog
:cl:
fix: Add a check if the vampire is a roundstart(it includes late join) vampire or not .
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
