### PR TITLE
Adds police vendor to the PD

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -207,7 +207,7 @@
 /obj/machinery/mineral/equipment_vendor/fastfood/police/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/card/id/police))
 		if(world.time - last_card_use_time >= 2 MINUTES)
-			points = points+6
+			points = points+15
 			last_card_use_time = world.time
 		else
 			to_chat(user, "<span class='alert'>You've hit your requisitions limit, come back soon.</span>")

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -204,6 +204,16 @@
 		return
 	return ..()
 
+/obj/machinery/mineral/equipment_vendor/fastfood/police/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/card/id/police))
+		if(world.time - last_card_use_time >= 2 MINUTES)
+			points = points+6
+			last_card_use_time = world.time
+		else
+			to_chat(user, "<span class='alert'>You've hit your requisitions limit, come back soon.</span>")
+	if(istype(I, /obj/item/stack/dollar))
+		return
+
 /obj/machinery/mineral/equipment_vendor/proc/RedeemVoucher(obj/item/mining_voucher/voucher, mob/redeemer)
 	var/items = list("Survival Capsule and Explorer's Webbing", "Resonator Kit", "Minebot Kit", "Extraction and Rescue Kit", "Crusher Kit", "Mining Conscription Kit")
 

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -212,6 +212,7 @@
 		else
 			to_chat(user, "<span class='alert'>You've hit your requisitions limit, come back soon.</span>")
 	if(istype(I, /obj/item/stack/dollar))
+		to_chat(user, "<span class='alert'>You can only use a police badge here.</span>")
 		return
 
 /obj/machinery/mineral/equipment_vendor/proc/RedeemVoucher(obj/item/mining_voucher/voucher, mob/redeemer)

--- a/code/modules/wod13/food.dm
+++ b/code/modules/wod13/food.dm
@@ -274,6 +274,7 @@
 	icon_state = "menu"
 	icon_deny = "menu"
 	prize_list = list()
+	var/dispenses_dollars = TRUE
 
 /obj/machinery/mineral/equipment_vendor/fastfood/sodavendor
 	name = "Drink Vendor"
@@ -308,7 +309,7 @@
 
 /obj/machinery/mineral/equipment_vendor/fastfood/AltClick(mob/user)
 	. = ..()
-	if(points)
+	if(points && dispenses_dollars)
 		for(var/i in 1 to points)
 			new /obj/item/stack/dollar(loc)
 		points = 0
@@ -567,6 +568,18 @@
 		new /datum/data/mining_equipment("surgical apron", /obj/item/clothing/suit/apron/surgical, 100),
 		new /datum/data/mining_equipment("latex gloves", /obj/item/clothing/gloves/vampire/latex, 100),
 		new /datum/data/mining_equipment("burn ointment", /obj/item/stack/medical/ointment, 100)
+	)
+
+/obj/machinery/mineral/equipment_vendor/fastfood/police
+	var/last_card_use_time = 0
+	dispenses_dollars = FALSE
+	prize_list = list(
+		new /datum/data/mining_equipment("handcuffs", /obj/item/restraints/handcuffs, 1),
+		new /datum/data/mining_equipment("camera", /obj/item/camera, 1),
+		new /datum/data/mining_equipment("tape recorder", /obj/item/taperecorder, 1),
+		new /datum/data/mining_equipment("white crayon", /obj/item/toy/crayon/white, 1),
+		new /datum/data/mining_equipment("evidence box", /obj/item/storage/box/evidence, 1),
+		new /datum/data/mining_equipment("body bags", /obj/item/storage/box/bodybags, 1)
 	)
 
 /obj/machinery/mineral/equipment_vendor/fastfood/smoking

--- a/code/modules/wod13/food.dm
+++ b/code/modules/wod13/food.dm
@@ -575,11 +575,18 @@
 	dispenses_dollars = FALSE
 	prize_list = list(
 		new /datum/data/mining_equipment("handcuffs", /obj/item/restraints/handcuffs, 1),
-		new /datum/data/mining_equipment("camera", /obj/item/camera, 1),
-		new /datum/data/mining_equipment("tape recorder", /obj/item/taperecorder, 1),
+		new /datum/data/mining_equipment("camera", /obj/item/camera, 2),
+		new /datum/data/mining_equipment("tape recorder", /obj/item/taperecorder, 2),
 		new /datum/data/mining_equipment("white crayon", /obj/item/toy/crayon/white, 1),
 		new /datum/data/mining_equipment("evidence box", /obj/item/storage/box/evidence, 1),
-		new /datum/data/mining_equipment("body bags", /obj/item/storage/box/bodybags, 1)
+		new /datum/data/mining_equipment("body bags", /obj/item/storage/box/bodybags, 1),
+		new /datum/data/mining_equipment("police vest", /obj/item/clothing/suit/vampire/vest/police, 1),
+		new /datum/data/mining_equipment("police radio", /obj/item/radio/cop, 2),
+		new /datum/data/mining_equipment("police uniform", /obj/item/clothing/under/vampire/police, 1),
+		new /datum/data/mining_equipment("police hat", /obj/item/clothing/head/vampire/police, 1),
+		new /datum/data/mining_equipment("flashlight", /obj/item/flashlight, 1),
+		new /datum/data/mining_equipment("magnifier", /obj/item/detective_scanner, 4)
+
 	)
 
 /obj/machinery/mineral/equipment_vendor/fastfood/smoking


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a police vendor with multiple items - cameras, recorders, white crayon, handcuffs, body bags, evidence box and multiple others. To use it, click the vendor with a police badge, then it will add 12 points to the vendor. This can only be done once every 2 minutes to prevent abuse. Likewise, money can't be taken out of this vendor, nor be added.
PR'd code-wise, will have to be added on the map after to avoid PR conflicts.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gives the police some QoL
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added a police vendor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
