### PR TITLE
Frenzy tweaks + fearless to fire kindred fix (unfunctional)

### DIFF
--- a/code/modules/vtmb/artifacts.dm
+++ b/code/modules/vtmb/artifacts.dm
@@ -101,7 +101,7 @@
 
 /obj/item/vtm_artifact/saulocept/get_powers()
 	..()
-	owner.experience_plus = 10
+	owner.experience_plus = 5
 
 /obj/item/vtm_artifact/saulocept/remove_powers()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Poorly and shoddily attempts to patch up frenzy code and rotshrek's old step away when being too close to a fire (which when it worked was too severe and annoying)
Most changes regarding fearstack and the uncommented back in blood frenzy tested and seem to be working (?) and values already lowered so it's not a constant thing. 

It's mostly the fear atom and/or step away being the issue I can't solve, so please delete my awful attempt to fix it and do it better or yell at how it should be done.

+ Also lowers saulocept XP gains since the xp hungry should not be so well fed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Kindred can stand right next to huge infernos without flinching right now.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked a few things
balance: the range NPCs spot frenzy-iers
fix: barely anything I need assistance

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
