### PR TITLE
Add a choice to keep being a vampire after a embrace or after being turned into a ghoul

### DIFF
--- a/code/modules/vtmb/kindred_species.dm
+++ b/code/modules/vtmb/kindred_species.dm
@@ -399,6 +399,7 @@
 						log_game("[key_name(H)] has Embraced [key_name(BLOODBONDED)].")
 						message_admins("[ADMIN_LOOKUPFLW(H)] has Embraced [ADMIN_LOOKUPFLW(BLOODBONDED)].")
 						giving = FALSE
+						var/save_data_v = FALSE
 						if(BLOODBONDED.revive(full_heal = TRUE, admin_revive = TRUE))
 							BLOODBONDED.grab_ghost(force = TRUE)
 							to_chat(BLOODBONDED, "<span class='userdanger'>You rise with a start, you're alive! Or not... You feel your soul going somewhere, as you realize you are embraced by a vampire...</span>")

--- a/code/modules/vtmb/kindred_species.dm
+++ b/code/modules/vtmb/kindred_species.dm
@@ -402,30 +402,91 @@
 						if(BLOODBONDED.revive(full_heal = TRUE, admin_revive = TRUE))
 							BLOODBONDED.grab_ghost(force = TRUE)
 							to_chat(BLOODBONDED, "<span class='userdanger'>You rise with a start, you're alive! Or not... You feel your soul going somewhere, as you realize you are embraced by a vampire...</span>")
+							var/response_v = input(BLOODBONDED, "Do you wish to keep being a vampire on your save slot?(Yes will be a permanent choice and you can't go back!)") in list("Yes", "No")
+							if(response_v == "Yes")
+								save_data_v = TRUE
+							else
+								save_data_v = FALSE
 						BLOODBONDED.roundstart_vampire = FALSE
 						BLOODBONDED.set_species(/datum/species/kindred)
-						BLOODBONDED.generation = H.generation+1
+						BLOODBONDED.clane = null
 						if(H.generation < 13)
 							BLOODBONDED.skin_tone = get_vamp_skin_color(BLOODBONDED.skin_tone)
 							BLOODBONDED.update_body()
-							BLOODBONDED.clane = new H.clane.type()
+							if (H.clane.whitelisted)
+								if (!SSwhitelists.is_whitelisted(BLOODBONDED.ckey, H.clane.name))
+									if(H.clane.name == "True Brujah")
+										BLOODBONDED.clane = new /datum/vampireclane/brujah()
+										to_chat(BLOODBONDED,"<span class='warning'> You don't got that whitelist! Changing to the non WL Brujah</span>")
+									else if(H.clane.name == "Tzimisce")
+										BLOODBONDED.clane = new /datum/vampireclane/old_clan_tzimisce()
+										to_chat(BLOODBONDED,"<span class='warning'> You don't got that whitelist! Changing to the non WL Old Tzmisce</span>")
+									else
+										to_chat(BLOODBONDED,"<span class='warning'> You don't got that whitelist! Changing to a random non WL clan.</span>")
+										var/list/non_whitelisted_clans = list(/datum/vampireclane/brujah,/datum/vampireclane/malkavian,/datum/vampireclane/nosferatu,/datum/vampireclane/gangrel,/datum/vampireclane/giovanni,/datum/vampireclane/ministry,/datum/vampireclane/salubri,/datum/vampireclane/toreador,/datum/vampireclane/tremere,/datum/vampireclane/ventrue)
+										var/random_clan = pick(non_whitelisted_clans)
+										BLOODBONDED.clane = new random_clan
+								else
+									BLOODBONDED.clane = new H.clane.type()
+							else
+								BLOODBONDED.clane = new H.clane.type()
+
 							BLOODBONDED.clane.on_gain(BLOODBONDED)
+							BLOODBONDED.clane.post_gain(BLOODBONDED)
 							if(BLOODBONDED.clane.alt_sprite)
 								BLOODBONDED.skin_tone = "albino"
 								BLOODBONDED.update_body()
+
 							//Gives the Childe the Sire's first three Disciplines
-							var/list/disciplines_to_give = list()
-							for (var/i in 1 to min(3, H.client.prefs.discipline_types.len))
-								disciplines_to_give += H.client.prefs.discipline_types[i]
-							BLOODBONDED.create_disciplines(FALSE, disciplines_to_give)
+
+							for (var/type_path in BLOODBONDED.clane.clane_disciplines)
+								var/datum/discipline/discipline_instance = new type_path
+								discipline_instance.level = 1
+								BLOODBONDED.give_discipline(discipline_instance)
 							BLOODBONDED.maxbloodpool = 10+((13-min(13, BLOODBONDED.generation))*3)
 							BLOODBONDED.clane.enlightenment = H.clane.enlightenment
-							if(BLOODBONDED.generation < 13)
-								BLOODBONDED.maxHealth = round((initial(BLOODBONDED.maxHealth)-initial(BLOODBONDED.maxHealth)/4)+(initial(BLOODBONDED.maxHealth)/4)*(BLOODBONDED.physique+13-BLOODBONDED.generation))
-								BLOODBONDED.health = round((initial(BLOODBONDED.maxHealth)-initial(BLOODBONDED.maxHealth)/4)+(initial(BLOODBONDED.maxHealth)/4)*(BLOODBONDED.physique+13-BLOODBONDED.generation))
 						else
+							BLOODBONDED.maxbloodpool = 10+((13-min(13, BLOODBONDED.generation))*3)
+							BLOODBONDED.generation = 14
 							BLOODBONDED.clane = new /datum/vampireclane/caitiff()
+
+						//Verify if they accepted to save being a vampire
+						if (iskindred(BLOODBONDED) && save_data_v)
+							var/datum/preferences/BLOODBONDED_prefs_v = BLOODBONDED.client.prefs
+
+							BLOODBONDED_prefs_v.pref_species.id = "kindred"
+							BLOODBONDED_prefs_v.pref_species.name = "Vampire"
+							if(H.generation < 13)
+								
+								BLOODBONDED_prefs_v.clane = BLOODBONDED.clane
+								BLOODBONDED_prefs_v.generation = 13
+								BLOODBONDED_prefs_v.skin_tone = get_vamp_skin_color(BLOODBONDED.skin_tone)
+								BLOODBONDED_prefs_v.clane.enlightenment = H.clane.enlightenment
+								
+							
+								//Rarely the new mid round vampires get the 3 brujah skil(it is default)
+								//This will remove if it happens
+								if(BLOODBONDED_prefs_v.discipline_types.len == 3)
+									for (var/i in 1 to 3)
+										var/removing_discipline = BLOODBONDED_prefs_v.discipline_types[1] 
+										if (removing_discipline)
+											var/index = BLOODBONDED_prefs_v.discipline_types.Find(removing_discipline)
+											BLOODBONDED_prefs_v.discipline_types.Cut(index, index + 1) 
+											BLOODBONDED_prefs_v.discipline_levels.Cut(index, index + 1)
+									            
+								if(BLOODBONDED_prefs_v.discipline_types.len == 0)
+									for (var/i in 1 to 3)
+										BLOODBONDED_prefs_v.discipline_types += BLOODBONDED_prefs_v.clane.clane_disciplines[i]
+										BLOODBONDED_prefs_v.discipline_levels += 1
+								BLOODBONDED_prefs_v.save_character()
+
+							else
+								BLOODBONDED_prefs_v.generation = 13 // Game always set to 13 anyways, 14 is not possible.
+								BLOODBONDED_prefs_v.clane = new /datum/vampireclane/caitiff()
+								BLOODBONDED_prefs_v.save_character()
+
 					else
+
 						to_chat(owner, "<span class='notice'>[BLOODBONDED] is totally <b>DEAD</b>!</span>")
 						giving = FALSE
 						return
@@ -475,7 +536,10 @@
 						if(new_master)
 							G.changed_master = TRUE
 					else if(!iskindred(BLOODBONDED) && !isnpc(BLOODBONDED))
+						var/save_data_g = FALSE
 						BLOODBONDED.set_species(/datum/species/ghoul)
+						BLOODBONDED.clane = null
+						var/response_g = input(BLOODBONDED, "Do you wish to keep being a ghoul on your save slot?(Yes will be a permanent choice and you can't go back)") in list("Yes", "No")
 //						if(BLOODBONDED.hud_used)
 //							var/datum/hud/human/HU = BLOODBONDED.hud_used
 //							HU.create_ghoulic()
@@ -485,6 +549,22 @@
 						G.last_vitae = world.time
 						if(new_master)
 							G.changed_master = TRUE
+						if(response_g == "Yes")
+							save_data_g = TRUE
+						else
+							save_data_g = FALSE
+						if(save_data_g)
+							var/datum/preferences/BLOODBONDED_prefs_g = BLOODBONDED.client.prefs
+							if(BLOODBONDED_prefs_g.discipline_types.len == 3)
+								for (var/i in 1 to 3)
+									var/removing_discipline = BLOODBONDED_prefs_g.discipline_types[1] 
+									if (removing_discipline)
+										var/index = BLOODBONDED_prefs_g.discipline_types.Find(removing_discipline)
+										BLOODBONDED_prefs_g.discipline_types.Cut(index, index + 1) 
+										BLOODBONDED_prefs_g.discipline_levels.Cut(index, index + 1)
+							BLOODBONDED_prefs_g.pref_species.name = "Ghoul"
+							BLOODBONDED_prefs_g.pref_species.id = "ghoul"
+							BLOODBONDED_prefs_g.save_character()
 			else
 				giving = FALSE
 

--- a/code/modules/vtmb/kindred_species.dm
+++ b/code/modules/vtmb/kindred_species.dm
@@ -441,10 +441,11 @@
 
 							//Gives the Childe the Sire's first three Disciplines
 
-							for (var/type_path in BLOODBONDED.clane.clane_disciplines)
-								var/datum/discipline/discipline_instance = new type_path
-								discipline_instance.level = 1
-								BLOODBONDED.give_discipline(discipline_instance)
+							var/list/disciplines_to_give = list()
+							for (var/i in 1 to min(3, H.client.prefs.discipline_types.len))
+								disciplines_to_give += H.client.prefs.discipline_types[i]
+							BLOODBONDED.create_disciplines(FALSE, disciplines_to_give)
+
 							BLOODBONDED.maxbloodpool = 10+((13-min(13, BLOODBONDED.generation))*3)
 							BLOODBONDED.clane.enlightenment = H.clane.enlightenment
 						else

--- a/code/modules/vtmb/kindred_species.dm
+++ b/code/modules/vtmb/kindred_species.dm
@@ -411,6 +411,7 @@
 						BLOODBONDED.set_species(/datum/species/kindred)
 						BLOODBONDED.clane = null
 						if(H.generation < 13)
+							BLOODBONDED.generation = 13
 							BLOODBONDED.skin_tone = get_vamp_skin_color(BLOODBONDED.skin_tone)
 							BLOODBONDED.update_body()
 							if (H.clane.whitelisted)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

After being transformed into a vampire/ghoul, now you can pick between "Yes" or "No" to save that change on your slot, keep in mind that WL clans for those without the WL, will be changed to their non WL versions or randomized.
For power gaming reason, if your sire is below the 13 gen, you will always be a 13th gen as well, if they are 13th gen you will be turned into a Caitiff 14th gen but unfortunately the game by default will force the 14th gen to turn 13th on the char slot.

On a side note for coders, create_disciplines does not work if you pass a list, i tried a couple of time to fix but it was not my focus so i used give_discipline directly, that also means that gargoyles created ingame don't recieve their disciplines.

Vamp choice:
![vamp_ask](https://github.com/user-attachments/assets/f2916695-312e-4b62-a44f-5746a3eecfdb)

Ghoul choice:
![ghoul_choice](https://github.com/user-attachments/assets/9aacb702-c615-4d3f-ae25-d14ac8591923)


## Why It's Good For The Game

This is mainly for rp reasons, so people call roleplay as real sire/child or turn a human into a ghoul and they choose to keep,
also WLs can make their story based of a real player as their sire and that can happen mechanically.
Also someone who plays human alot and spent alot of xp on it can turn into a vampire/ghoul without the need to reset their stats.

## Changelog
:cl:
Add: A choice to keep the vampire change on your slot after being transformed
Add: A choice to keep the ghoul change on your slot after being transformed.
Fix: The child of a embrace now gain their skills
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
