### PR TITLE
[HOTFIX] Important contact not existing if someone rolled that role from roundstart

### DIFF
--- a/code/modules/vtmb/electronics/phones/phone.dm
+++ b/code/modules/vtmb/electronics/phones/phone.dm
@@ -69,7 +69,7 @@
 			var/mob/living/carbon/human/H = loc
 			if(H.Myself)
 				H.Myself.phone_number = number
-				owner = H.true_real_name
+				owner = H.real_name
 
 /obj/item/vamp/phone/Destroy()
 	GLOB.phone_numbers_list -= number

--- a/code/modules/vtmb/electronics/phones/phone.dm
+++ b/code/modules/vtmb/electronics/phones/phone.dm
@@ -62,6 +62,9 @@
 	. = ..()
 	RegisterSignal(src, COMSIG_MOVABLE_HEAR, PROC_REF(handle_hearing))
 	if(!number || number == "")
+		if(ishuman(loc))
+			var/mob/living/carbon/human/H_O = loc
+			owner = H_O.real_name
 		number = create_unique_phone_number(exchange_num)
 		GLOB.phone_numbers_list += number
 		GLOB.phones_list += src
@@ -69,7 +72,6 @@
 			var/mob/living/carbon/human/H = loc
 			if(H.Myself)
 				H.Myself.phone_number = number
-				owner = H.real_name
 
 /obj/item/vamp/phone/Destroy()
 	GLOB.phone_numbers_list -= number


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

[Compiled Tested and tested ingame]

Really stupid oversight that i thought that it was fixed, since i never tested readying from the round start, now finnaly if you roll prince, sherif etc from round start your contact will appear fine and with the name.

## Why It's Good For The Game

Fix

## Changelog
:cl:
:fix: Fix owner recieving their name too late, when it was added to the glob it was empty.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
