### PR TITLE
Renames the sewer's "shit" tiles to be "sewage"

### DIFF
--- a/code/modules/wod13/wallcode.dm
+++ b/code/modules/wod13/wallcode.dm
@@ -1076,7 +1076,7 @@
 
 /turf/open/floor/plating/shit
 	gender = PLURAL
-	name = "shit"
+	name = "sewage"
 	icon = 'code/modules/wod13/tiles.dmi'
 	icon_state = "shit"
 	flags_1 = NONE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Renames shit to sewage.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Sewage is more fun to tread through than shit! (why was sewage named 'shit' in the first place? russians ig)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:

tweak: changed the descriptive name of 'shit' tiles to 'sewage'

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
