### PR TITLE
Vampires heal far less burn damage

### DIFF
--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -223,6 +223,14 @@
 /mob/living/carbon/heal_overall_damage(brute = 0, burn = 0, stamina = 0, required_status, updating_health = TRUE)
 	var/list/obj/item/bodypart/parts = get_damaged_bodyparts(brute, burn, stamina, required_status)
 
+	//Modify the damage according to the target's species ahead of time.
+	//We are not making a human subtype of heal_overall_damage yet, so this should suffice.
+	if(ishuman(src))
+		var/mob/living/carbon/human/H = src
+		if(H.dna && H.dna.species)
+			brute *= H.dna.species.brute_heal_mod
+			burn *= H.dna.species.burn_heal_mod
+
 	var/update = NONE
 	while(parts.len && (brute > 0 || burn > 0 || stamina > 0))
 		var/obj/item/bodypart/picked = pick(parts)
@@ -231,16 +239,7 @@
 		var/burn_was = picked.burn_dam
 		var/stamina_was = picked.stamina_dam
 
-		//We are not making a human subtype of heal_overall_damage yet, so this should suffice.
-		var/brute_modifier = 1
-		var/burn_modifier = 1
-		if(ishuman(src))
-			var/mob/living/carbon/human/H = src
-			if(H.dna && H.dna.species)
-				brute_modifier = H.dna.species.brute_heal_mod
-				burn_modifier = H.dna.species.burn_heal_mod
-
-		update |= picked.heal_damage(brute * brute_modifier, burn * burn_modifier, stamina, required_status, FALSE)
+		update |= picked.heal_damage(brute, burn, stamina, required_status, FALSE)
 
 		brute = round(brute - (brute_was - picked.brute_dam), DAMAGE_PRECISION)
 		burn = round(burn - (burn_was - picked.burn_dam), DAMAGE_PRECISION)

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -223,7 +223,7 @@
 /mob/living/carbon/heal_overall_damage(brute = 0, burn = 0, stamina = 0, required_status, updating_health = TRUE)
 	var/list/obj/item/bodypart/parts = get_damaged_bodyparts(brute, burn, stamina, required_status)
 
-	//Modify the damage according to the target's species ahead of time.
+	//Modify the healing according to the target's species ahead of time.
 	//We are not making a human subtype of heal_overall_damage yet, so this should suffice.
 	if(ishuman(src))
 		var/mob/living/carbon/human/H = src

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -231,7 +231,16 @@
 		var/burn_was = picked.burn_dam
 		var/stamina_was = picked.stamina_dam
 
-		update |= picked.heal_damage(brute, burn, stamina, required_status, FALSE)
+		//We are not making a human subtype of heal_overall_damage yet, so this should suffice.
+		var/brute_modifier = 1
+		var/burn_modifier = 1
+		if(ishuman(src))
+			var/mob/living/carbon/human/H = src
+			if(H.dna && H.dna.species)
+				brute_modifier = H.dna.species.brute_heal_mod
+				burn_modifier = H.dna.species.burn_heal_mod
+
+		update |= picked.heal_damage(brute * brute_modifier, burn * burn_modifier, stamina, required_status, FALSE)
 
 		brute = round(brute - (brute_was - picked.brute_dam), DAMAGE_PRECISION)
 		burn = round(burn - (burn_was - picked.burn_dam), DAMAGE_PRECISION)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -90,6 +90,9 @@ GLOBAL_LIST_EMPTY(selectable_races)
 	var/heatmod = 1
 	///multiplier for stun durations
 	var/stunmod = 1
+	///healing modifiers
+	var/brute_heal_mod = 1
+	var/burn_heal_mod = 1
 	///multiplier for money paid at payday
 	var/payday_modifier = 1
 	///Type of damage attack does. Ethereals attack with burn damage for example.

--- a/code/modules/vtmb/kindred_species.dm
+++ b/code/modules/vtmb/kindred_species.dm
@@ -27,6 +27,7 @@
 	brutemod = 0.5	// or change to 0.8
 	heatmod = 1		//Sucking due to overheating	///THEY DON'T SUCK FROM FIRE ANYMORE
 	burnmod = 2
+	burn_heal_mod = 0.2 //Aggravated damage from fire is far harder to heal. At max blood heal this should also mean 16 burn damage healed. Ouch.
 	punchdamagelow = 10
 	punchdamagehigh = 20
 	dust_anim = "dust-h"


### PR DESCRIPTION
Vampires now only heal 1/5th of the burn damage they receive because it is aggravated damage. A 9th-gen's blood heal (the generation limit at which blood heal is maximized) goes from healing 80 burn damage to healing 16 burn damage.

Also adds support for species having different healing multipliers for brute and burn damage.