### PR TITLE
Minor arsenal pass for kiasyd

### DIFF
--- a/code/modules/wod13/guns.dm
+++ b/code/modules/wod13/guns.dm
@@ -115,6 +115,7 @@
 	fire_sound_volume = 65
 	projectile_damage_multiplier = 1.2 //21.6 damage, slightly higher than the m1911, just so it is possible to kill NPCs within 6 bullets
 	cost = 20
+	is_iron = FALSE
 
 /obj/item/ammo_box/magazine/internal/cylinder/rev9mm
 	name = "revolver cylinder"
@@ -160,6 +161,7 @@
 	bolt_drop_sound = 'sound/weapons/gun/pistol/drop_small.ogg'
 	fire_sound_volume = 75
 	cost = 75
+	is_iron = FALSE
 
 /obj/item/ammo_box/magazine/m50
 	name = "handgun magazine (.50)"
@@ -182,6 +184,7 @@
 	worn_icon_state = "deagle"
 	mag_type = /obj/item/ammo_box/magazine/m50
 	fire_sound_volume = 125 //MY EARS
+	is_iron = FALSE
 
 /obj/item/ammo_box/magazine/vamp45acp
 	name = "pistol magazine (.45 ACP)"
@@ -220,6 +223,7 @@
 	bolt_drop_sound = 'sound/weapons/gun/pistol/drop_small.ogg'
 	fire_sound_volume = 100
 	cost = 55
+	is_iron = FALSE
 
 /obj/item/ammo_box/magazine/glock9mm
 	name = "automatic pistol magazine (9mm)"
@@ -328,6 +332,7 @@
 	rack_sound = 'sound/weapons/gun/pistol/slide_lock.ogg'
 	fire_sound = 'code/modules/wod13/sounds/uzi.ogg'
 	cost = 175
+	is_iron = FALSE
 
 /obj/item/ammo_box/magazine/vamp9mp5
 	name = "mp5 magazine (9mm)"
@@ -358,6 +363,7 @@
 	rack_sound = 'sound/weapons/gun/pistol/slide_lock.ogg'
 	fire_sound = 'code/modules/wod13/sounds/mp5.ogg'
 	cost = 200
+	is_iron = FALSE
 
 /obj/item/ammo_box/magazine/vamp556
 	name = "carbine magazine (5.56mm)"
@@ -390,6 +396,7 @@
 	fire_sound = 'code/modules/wod13/sounds/rifle.ogg'
 	masquerade_violating = TRUE
 	cost = 250
+	is_iron = FALSE
 
 /obj/item/ammo_box/magazine/vamp545
 	name = "rifle magazine (5.45mm)"
@@ -423,6 +430,7 @@
 	fire_sound = 'code/modules/wod13/sounds/ak.ogg'
 	masquerade_violating = TRUE
 	cost = 225
+	is_iron = FALSE
 
 /obj/item/ammo_box/magazine/vampaug
 	name = "AUG magazine (5.56mm)"
@@ -489,6 +497,7 @@
 	fire_sound = 'code/modules/wod13/sounds/thompson.ogg'
 	masquerade_violating = TRUE
 	cost = 250
+	is_iron = FALSE
 
 /obj/item/ammo_box/magazine/internal/vampire/sniper
 	name = "sniper rifle internal magazine"
@@ -528,6 +537,7 @@
 	actions_types = list()
 	masquerade_violating = TRUE
 	cost = 250
+	is_iron = FALSE
 
 /obj/item/ammo_box/magazine/internal/vampshotgun
 	name = "shotgun internal magazine"
@@ -557,6 +567,7 @@
 	recoil = 4
 	inhand_x_dimension = 32
 	inhand_y_dimension = 32
+	is_iron = FALSE
 
 /obj/item/gun/ballistic/shotgun/toy/crossbow/vampire
 	name = "crossbow"

--- a/code/modules/wod13/guns.dm
+++ b/code/modules/wod13/guns.dm
@@ -258,6 +258,7 @@
 	bolt_drop_sound = 'sound/weapons/gun/pistol/drop_small.ogg'
 	fire_sound_volume = 100
 	cost = 70
+	is_iron = FALSE
 
 /obj/item/ammo_box/magazine/glock45acp
 	name = "automatic pistol magazine (.45 ACP)"
@@ -296,6 +297,7 @@
 	bolt_drop_sound = 'sound/weapons/gun/pistol/drop_small.ogg'
 	fire_sound_volume = 100
 	cost = 150
+	is_iron = FALSE
 
 /obj/item/ammo_box/magazine/vamp9mm
 	name = "uzi magazine (9mm)"

--- a/code/modules/wod13/melee.dm
+++ b/code/modules/wod13/melee.dm
@@ -553,7 +553,7 @@
 	armor = list(MELEE = 25, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 0)
 	resistance_flags = FIRE_PROOF
 	masquerade_violating = FALSE
-	is_iron = TRUE
+	is_iron = FALSE
 
 /obj/item/melee/vampirearms/shovel/attack(mob/living/target, mob/living/user)
 	. = ..()
@@ -582,6 +582,7 @@
 	bare_wound_bonus = 10
 	resistance_flags = FIRE_PROOF
 	masquerade_violating = TRUE
+	is_iron = FALSE
 
 /obj/item/melee/vampirearms/eguitar
 	icon = 'code/modules/wod13/48x32weapons.dmi'


### PR DESCRIPTION
## About The Pull Request
Grants kiasyd access to two more melee weapons and two pistols so they can have some tools to work with.

## Why It's Good For The Game
Kiasyd were limited to just the axe, bat, tentacles, aug and crossbow for their arsenal in terms of availability. This at least grants them something to a more accessible in ranged options albeit still costly and one also only being found on FBI agents. Along, with adding two melee weapons originally missed. 

Edit: Someone pointed out because in my ever constant stupidity, that most guns would be different metals than iron.

## Changelog
:cl:
add: ALL GUNS NOW, Scythe, and Shovel to be useable by them

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
