### PR TITLE
Bloodwalk ritual

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -251,6 +251,12 @@
 		blood_data["donor"] = src
 		blood_data["viruses"] = list()
 
+		blood_data["generation"] = src.generation
+		if(istype(src, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = src
+			if(H.clane)
+				blood_data["clan"] = H.clane.name
+
 		for(var/thing in diseases)
 			var/datum/disease/D = thing
 			blood_data["viruses"] += D.Copy()

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1,5 +1,5 @@
 /datum/reagent/blood
-	data = list("donor"=null,"viruses"=null,"blood_DNA"=null,"blood_type"=null,"resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null,"cloneable"=null,"factions"=null,"quirks"=null)
+	data = list("donor"=null,"viruses"=null,"blood_DNA"=null,"blood_type"=null,"resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null,"cloneable"=null,"factions"=null,"quirks"=null,"clan"=null,"generation"=null)
 	name = "Blood"
 	color = "#C80000" // rgb: 200, 0, 0
 	metabolization_rate = 5 //fast rate so it disappears fast.

--- a/code/modules/vtmb/magic/pyramid.dm
+++ b/code/modules/vtmb/magic/pyramid.dm
@@ -261,7 +261,7 @@
 	icon_state = "rune6"
 	word = "POR'TALE"
 	thaumlevel = 5
-	sacrifices = list(/obj/item/drinkable_bloodpack/vitae)
+	sacrifices = list(/obj/item/drinkable_bloodpack)
 
 /obj/ritualrune/teleport/complete()
 	if(!activated)
@@ -431,3 +431,86 @@
 		playsound(loc, 'code/modules/wod13/sounds/thaum.ogg', 50, FALSE)
 		color = rgb(255,0,0)
 		activated = TRUE
+
+/obj/ritualrune/bloodwalk
+	name = "Blood Walk"
+	desc = "Trace the subject's lineage from a blood syringe."
+	icon_state = "rune7"
+	word = "Reveal thine bloodline for my eyes."
+	thaumlevel = 2
+
+/obj/ritualrune/bloodwalk/attack_hand(mob/user)
+	for(var/obj/item/reagent_containers/syringe/S in loc)
+		if(S)
+			for(var/datum/reagent/blood/B in S.reagents.reagent_list)
+				if(B)
+					if(B.type == /datum/reagent/blood)
+						var/blood_data = B.data
+						if(blood_data)
+							var/generation = blood_data["generation"]
+							var/clan = blood_data["clan"]
+
+							var/message = generate_message(generation, clan)
+							to_chat(user, "[message]")
+						else
+							to_chat(user, "The blood speaks not-it is empty of power!")
+					else
+						to_chat(user, "This reagent is lifeless, unworthy of the ritual!")
+		playsound(loc, 'code/modules/wod13/sounds/thaum.ogg', 50, FALSE)
+		color = rgb(255,0,0)
+		activated = TRUE
+		qdel(src)
+
+/obj/ritualrune/bloodwalk/proc/generate_message(generation, clan)
+	var/message = ""
+
+	if(generation == 4)
+		message += "The blood is incredibly ancient and powerful! It must be from an ancient Methuselah! "
+	else if(generation == 5)
+		message += "The blood is incredibly ancient and powerful! It must be from a Methuselah! "
+	else if(generation == 6)
+		message += "The blood is incredibly ancient and powerful! It must be from an Elder! "
+	else if(generation == 7 || generation == 8 || generation == 9)
+		message += "The blood is powerful. It must come from an Ancilla or Elder! "
+	else if(generation == 10 || generation == 11)
+		message += "The blood is of middling strength. It must come from someone young. "
+	else if(generation >=12)
+		message += "The blood is of waning strength. It must come from a neonate. "
+
+	if(clan == "Toreador" || clan == "Daughters of Cacophony")
+		message += "The blood is sweet and rich. The owner must, too, be beautiful."
+	else if(clan == "Ventrue")
+		message += "The blood has kingly power in it, descending from Mithras or Hardestadt."
+	else if(clan == "Lasombra")
+		message += "Cold and dark, this blood has a mystical connection to the Abyss."
+	else if(clan == "Tzimisce")
+		message += "The vitae is mutable and twisted. Is there any doubt to the cursed line it belongs to?"
+	else if(clan == "Gangrel")
+		message += "The blood emits a primal and feral aura. The same is likely of the owner."
+	else if(clan == "Malkavian")
+		message += "You can sense chaos and madness within this blood. It's owner must be maddened too."
+	else if(clan == "Brujah")
+		message += "The blood is filled with passion and anger. So must be the owner of the blood."
+	else if(clan == "Nosferatu")
+		message += "The blood is foul and disgusting. Same must apply to the owner."
+	else if(clan == "Tremere")
+		message += "The blood is filled with the power of magic. The owner must be a thaumaturge."
+	else if(clan == "Baali")
+		message += "Tainted and corrupt. Vile and filthy. You see your reflection in the blood, but something else stares back."
+	else if(clan == "Assamite")
+		message += "Potent... Deadly... And cursed. You know well the curse laid by Tremere on the assassins."
+	else if(clan == "True Brujah")
+		message += "The blood is cold and static... It's hard to feel any emotion within it."
+	else if(clan == "Salubri")
+		message += "The cursed blood of the Salubri! The owner of this blood must be slain."
+	else if(clan == "Giovanni" || clan == "Cappadocian")
+		message += "The blood is very cold and filled with death. The owner must be a necromancer."
+	else if(clan == "Kiasyd")
+		message += "The blood is filled with traces of fae magic."
+	else if(clan == "Gargoyle")
+		message += "The blood of our stone servants."
+	else if(clan == "Ministry")
+		message += "Seduction and allure are in the blood. Ah, one of the snakes."
+	else
+		message += "The blood's origin is hard to trace. Perhaps it is one of the clanless?"
+	return message

--- a/code/modules/wod13/food.dm
+++ b/code/modules/wod13/food.dm
@@ -551,7 +551,8 @@
 		new /datum/data/mining_equipment("potassium iodide pill bottle", /obj/item/storage/pill_bottle/potassiodide, 100),
 		new /datum/data/mining_equipment("bruise pack", /obj/item/stack/medical/bruise_pack, 100),
 		new /datum/data/mining_equipment("burn ointment", /obj/item/stack/medical/ointment, 100),
-		new /datum/data/mining_equipment("latex gloves", /obj/item/clothing/gloves/vampire/latex, 150)
+		new /datum/data/mining_equipment("latex gloves", /obj/item/clothing/gloves/vampire/latex, 150),
+		new /datum/data/mining_equipment("box of syringes", /obj/item/storage/box/syringes, 300)
 	)
 
 /obj/machinery/mineral/equipment_vendor/fastfood/hospital // we should probably swap from a vendor system and work on a sort of gameplay loop - tzula


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the Bloodwalk ritual that allows you to tell someone's generation and clan. Also adds syringe boxes to the pharmacy for 300 dollars each, and slightly buffs teleport by reducing the requirements to regular bloodbags.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Expands on the core features of Tremere that are sorely lacking.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added blood walk ritual
balance: rebalanced teleport ritual
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
