### PR TITLE
Makes bloodhunt name the author

### DIFF
--- a/code/modules/vtmb/gamemodes/bloodhunt.dm
+++ b/code/modules/vtmb/gamemodes/bloodhunt.dm
@@ -67,13 +67,14 @@ SUBSYSTEM_DEF(bloodhunt)
 			if(iskindred(H) || isghoul(H))
 				H.clear_alert("bloodhunt")
 
-/datum/controller/subsystem/bloodhunt/proc/announce_hunted(var/mob/living/target, var/reason)
+/datum/controller/subsystem/bloodhunt/proc/announce_hunted(var/mob/living/target, var/reason, var/user)
 	if(!ishuman(target))
 		return
 	var/mob/living/carbon/human/H = target
+	var/mob/living/carbon/human/U = user
 	if(!H.bloodhunted)
 		H.bloodhunted = TRUE
-		to_chat(world, "<b>The Blood Hunt after <span class='warning'>[H.true_real_name]</span> has been announced! <br> Reason: [reason]</b>")
+		to_chat(world, "<b>The Blood Hunt after <span class='warning'>[H.true_real_name]</span> has been announced by [U.true_real_name]! <br> Reason: [reason]</b>")
 		SEND_SOUND(world, sound('code/modules/wod13/sounds/announce.ogg'))
 		hunted += H
 		update_shit()

--- a/code/modules/wod13/special_shit.dm
+++ b/code/modules/wod13/special_shit.dm
@@ -176,11 +176,11 @@
 						to_chat(world, "<b>The Blood Hunt after <span class='green'>[H.true_real_name]</span> is over!</b>")
 						SEND_SOUND(world, sound('code/modules/wod13/sounds/announce.ogg'))
 					else
-						SSbloodhunt.announce_hunted(H, reason)
+						SSbloodhunt.announce_hunted(H, reason, user)
 						to_chat(user, "<span class='warning'>You add [chosen_name] to the Hunted list.</span>")
 					name_in_list = TRUE
 		if(!name_in_list)
-			to_chat(user, "<span class='warning'>There is no such names in the city!</span>")
+			to_chat(user, "<span class='warning'>There are no such names in the city!</span>")
 
 /obj/item/phone_book
 	name = "phone book"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Simple change that makes the bloodhunt display it's author to everyone, so that everyone knows if it's the prince or some random human using the skull.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's good for both admins and people to know in case someone abuses it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked blood hunt announcement
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
