### PR TITLE
Fix selling price bug

### DIFF
--- a/code/modules/wod13/lombard.dm
+++ b/code/modules/wod13/lombard.dm
@@ -17,7 +17,7 @@
 			return
 	if(W.cost > 0)
 		if(W.illegal == illegal)
-			for(var/i in 1 to (W.cost/5)*(user.get_total_social() * 0.1))
+			for(var/i in 1 to (W.cost / 5) * (user.social + (user.additional_social * 0.1)))
 				new /obj/item/stack/dollar(loc)
 			playsound(loc, 'code/modules/wod13/sounds/sell.ogg', 50, TRUE)
 			if(istype(W, /obj/item/organ))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a bug in #394 that would make items sell for FAR less independent of the user's social score due to an order of operations bug. Instead of user.social + user.additional_social * 0.1, it was doing (user.social + user.additional_social) * 0.1.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fix so you can sell things for actual money again.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: You can now sell items for normal prices again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
