### PR TITLE
Bank account codes are shorter

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -87,6 +87,7 @@
 		for(var/datum/bank_account/account in GLOB.bank_account_list)
 			if(host.bank_id == account.bank_id)
 				dat += "<b>My bank account code is: [account.code]</b><BR>"
+				break
 		host << browse(dat, "window=vampire;size=400x450;border=1;can_resize=1;can_minimize=0")
 		onclose(host, "vampire", src)
 

--- a/code/modules/vtmb/electronics/atms/atm.dm
+++ b/code/modules/vtmb/electronics/atms/atm.dm
@@ -1,6 +1,6 @@
 /proc/create_bank_code()
 	var/bank_code = ""
-	for(var/i = 1 to 10)
+	for(var/i = 1 to 4)
 		bank_code += "[rand(0, 9)]"
 	return bank_code
 


### PR DESCRIPTION
Shortens it to 4 digits, basically a PIN code. I always copypaste the 10-digit code instead of typing it by hand because it is annoying.