### PR TITLE
Makes so Mask hide the character name on the chat.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_say.dm
+++ b/code/modules/mob/living/carbon/human/human_say.dm
@@ -25,6 +25,30 @@
 			return ("Unknown")
 		else
 			return real_name
+	//Wod13 Masks
+	if(istype(wear_mask, /obj/item/clothing/mask/vampire))
+		var/obj/item/clothing/mask/vampire/V = wear_mask
+		if(V.voice_unknown)
+			return ("Unknown")
+		else
+			return real_name
+
+	if(istype(wear_mask, /obj/item/clothing/mask/animal))
+		var/obj/item/clothing/mask/animal/V = wear_mask
+		if(V.voice_unknown)
+			return ("Unknown")
+		else
+			return real_name
+
+	//Wod13 Head types, some are masks.
+	if(istype(head, /obj/item/clothing/head/vampire))
+		var/obj/item/clothing/mask/animal/V = head
+		if(V.voice_unknown)
+			return ("Unknown")
+		else
+			return real_name
+
+
 	if(mind)
 		var/datum/antagonist/changeling/changeling = mind.has_antag_datum(/datum/antagonist/changeling)
 		if(changeling?.mimicing )

--- a/code/modules/wod13/clothcode.dm
+++ b/code/modules/wod13/clothcode.dm
@@ -834,6 +834,7 @@
 	armor = list(MELEE = 10, BULLET = 0, LASER = 10, ENERGY = 10, BOMB = 10, BIO = 0, RAD = 0, FIRE = 0, ACID = 10, WOUND = 10)
 	body_worn = TRUE
 	cost = 10
+	var/voice_unknown = FALSE
 
 /obj/item/clothing/head/vampire/bandana
 	name = "bandana"
@@ -999,6 +1000,7 @@
 	dynamic_hair_suffix = ""
 	dynamic_fhair_suffix = ""
 	armor = list(MELEE = 10, BULLET = 0, LASER = 10, ENERGY = 10, BOMB = 10, BIO = 0, RAD = 0, FIRE = 0, ACID = 10, WOUND = 10)
+	voice_unknown = TRUE
 
 /obj/item/clothing/head/vampire/straw_hat
 	name = "straw hat"
@@ -1022,7 +1024,9 @@
 	name = "Noddist mask"
 	desc = "Shine black the sun! Shine blood the moon! Gehenna is coming soon."
 	icon_state = "noddist_mask"
+	flags_inv = HIDEFACE
 	armor = list(MELEE = 10, BULLET = 0, LASER = 10, ENERGY = 10, BOMB = 10, BIO = 0, RAD = 0, FIRE = 0, ACID = 10, WOUND = 10)
+	voice_unknown = TRUE
 
 /obj/item/clothing/head/vampire/kalimavkion
 	name = "Kalimavkion"
@@ -1165,6 +1169,7 @@
 	flags_cover = MASKCOVERSMOUTH | PEPPERPROOF
 	resistance_flags = NONE
 	body_worn = TRUE
+	var/voice_unknown = TRUE
 
 /obj/item/clothing/mask/vampire/balaclava
 	name = "balaclava"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I always found strange how masks protects from exam but once you say something your name is exposed, and i would stay between is it right to know their person name even with the mask and etc.
Now every new vamp mask or animal mask hides the person name when they say, it does not hide from the admin logs.

Examples:

![image](https://github.com/user-attachments/assets/260a2f7f-de64-4b83-a289-97a16ea356d3)

![vamp_mask](https://github.com/user-attachments/assets/2b54578b-3949-4973-a1de-d454d908cc55)

![animal_mask](https://github.com/user-attachments/assets/09549ac4-88b9-45f0-87f3-ad6f3229c50c)


## Why It's Good For The Game

Add another level of people being real secretive and distrust among peole who only uses masks, but there are methods against that, the masquerade contract will always reveal their name so it is pointless if you break the masquerade, also domination "WHO ARE YOU" will reveal their name.


## Changelog
:cl:
Tweak: Now vamp and animal masks hide their name on say
Fix: Head Nudist mask now hides your name on exam
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
