### PR TITLE
Seneschal and prince money adjustment, humanity adjustment for drug t…

### DIFF
--- a/code/modules/vtmb/electronics/atms/atm.dm
+++ b/code/modules/vtmb/electronics/atms/atm.dm
@@ -66,6 +66,10 @@ var/mob/living/carbon/human/H
 	icon_state = "card2"
 	inhand_icon_state = "card2"
 
+/obj/item/vamp/creditcard/seneschal
+	icon_state = "card2"
+	inhand_icon_state = "card2"
+
 /obj/item/vamp/creditcard/elder
 	icon_state = "card3"
 	inhand_icon_state = "card3"
@@ -83,13 +87,15 @@ var/mob/living/carbon/human/H
 	if(user)
 		owner = user.ckey
 	if(istype(src, /obj/item/vamp/creditcard/prince))
-		account.balance = rand(5000, 10000)
+		account.balance = rand(10000, 15000)
 	else if(istype(src, /obj/item/vamp/creditcard/elder))
 		account.balance = rand(3000, 7000)
 	else if(istype(src, /obj/item/vamp/creditcard/rich))
 		account.balance = rand(1000, 4000)
 	else if(istype(src, /obj/item/vamp/creditcard/giovanniboss))
 		account.balance = rand(8000, 15000)
+	else if(istype(src, /obj/item/vamp/creditcard/seneschal))
+		account.balance = rand(4000, 8000)
 	else
 		account.balance = rand(100, 1000)
 

--- a/code/modules/vtmb/jobs/seneschal.dm
+++ b/code/modules/vtmb/jobs/seneschal.dm
@@ -60,7 +60,7 @@
 //	head = /obj/item/clothing/head/hopcap
 	l_pocket = /obj/item/vamp/phone/clerk
 	r_pocket = /obj/item/vamp/keys/clerk
-	backpack_contents = list(/obj/item/passport=1, /obj/item/phone_book=1, /obj/item/cockclock=1, /obj/item/flashlight=1, /obj/item/vamp/creditcard=1)
+	backpack_contents = list(/obj/item/passport=1, /obj/item/phone_book=1, /obj/item/cockclock=1, /obj/item/flashlight=1, /obj/item/vamp/creditcard/seneschal=1)
 
 /datum/outfit/job/clerk/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/wod13/lombard.dm
+++ b/code/modules/wod13/lombard.dm
@@ -26,13 +26,13 @@
 				H.AdjustHumanity(-1, 0)
 			else if(istype(W, /obj/item/reagent_containers/food/drinks/meth/cocaine))
 				var/mob/living/carbon/human/H = user
-				H.AdjustHumanity(-1, 4)
+				H.AdjustHumanity(-1, 5)
 			else if(istype(W, /obj/item/reagent_containers/food/drinks/meth))
 				var/mob/living/carbon/human/H = user
-				H.AdjustHumanity(-1, 3)
+				H.AdjustHumanity(-1, 4)
 			else if(illegal)
 				var/mob/living/carbon/human/H = user
-				H.AdjustHumanity(-1, 5)
+				H.AdjustHumanity(-1, 7)
 			qdel(W)
 			return
 	else


### PR DESCRIPTION
…rade

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gives the prince an increased amount of money, a very big buff for the seneschal's income, and drug trade is re-adjusted a little bit.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It should make the prince's right hand more worthwhile on it's own, and weed taking you down to humanity 5 doesn't make sense anyway.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: changed up humanity adjustment for drugs, gave seneschal and prince more money
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
