### PR TITLE
Nerfs diablerie

### DIFF
--- a/code/modules/wod13/bloodsucking.dm
+++ b/code/modules/wod13/bloodsucking.dm
@@ -88,7 +88,7 @@
 					return
 
 				if(vse_taki)
-					to_chat(src, "<span class='userdanger'><b>YOU TRY TO COMMIT DIABLERIE OVER [mob].</b></span>")
+					to_chat(src, "<span class='userdanger'><b>YOU TRY TO COMMIT DIABLERIE ON [mob].</b></span>")
 				else
 					to_chat(src, "<span class='warning'>You find the idea of drinking your own <b>KIND</b> disgusting!</span>")
 					return
@@ -143,8 +143,6 @@
 						message_admins("[ADMIN_LOOKUPFLW(src)] successfully Diablerized [ADMIN_LOOKUPFLW(mob)]")
 						log_attack("[key_name(src)] successfully Diablerized [key_name(mob)].")
 						if(K.client)
-							K.generation = 13
-							P2.generation = 13
 							var/datum/brain_trauma/special/imaginary_friend/trauma = gain_trauma(/datum/brain_trauma/special/imaginary_friend)
 							trauma.friend.key = K.key
 						mob.death()
@@ -164,10 +162,9 @@
 							to_chat(src, "<span class='userdanger'><b>[K]'s SOUL OVERCOMES YOURS AND GAIN CONTROL OF YOUR BODY.</b></span>")
 							message_admins("[ADMIN_LOOKUPFLW(src)] tried to Diablerize [ADMIN_LOOKUPFLW(mob)] and was overtaken.")
 							log_attack("[key_name(src)] tried to Diablerize [key_name(mob)] and was overtaken.")
-							generation = 13
+							generation = min(13, P.generation+1)
 							death()
 							if(P)
-								P.generation = 13
 								P.reason_of_death = "Failed the Diablerie ([time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")])."
 //							ghostize(FALSE)
 //							key = K.key
@@ -180,14 +177,15 @@
 							log_attack("[key_name(src)] successfully Diablerized [key_name(mob)].")
 							if(P)
 								P.diablerist = 1
-								P.generation = K.generation
+								if(mob.generation + 3 > generation)
+									P.generation = max(P.generation - 2, 7)
+								else
+									P.generation = max(P.generation - 1, 7)
 								generation = P.generation
 							diablerist = 1
 							maxHealth = initial(maxHealth)+max(0, 50*(13-generation))
 							health = initial(health)+max(0, 50*(13-generation))
 							if(K.client)
-								K.generation = 13
-								P2.generation = 13
 								var/datum/brain_trauma/special/imaginary_friend/trauma = gain_trauma(/datum/brain_trauma/special/imaginary_friend)
 								trauma.friend.key = K.key
 							mob.death()

--- a/code/modules/wod13/bloodsucking.dm
+++ b/code/modules/wod13/bloodsucking.dm
@@ -177,7 +177,7 @@
 							log_attack("[key_name(src)] successfully Diablerized [key_name(mob)].")
 							if(P)
 								P.diablerist = 1
-								if(mob.generation + 3 > generation)
+								if(mob.generation + 3 < generation)
 									P.generation = max(P.generation - 2, 7)
 								else
 									P.generation = max(P.generation - 1, 7)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You no longer get reset to generation 13 by diablerie, as this is an extreme tool to allow (hypothetically) just about anyone to use on anyone they can robust. 
In addition, diablerie now simply lowers your generation by 1 on a successful attempt **(edit: when performed on someone of a lower generation),** or by 2 if the victim was at least 4 generations below you. _Failed_ diablerie raises your generation by 1.

## Why It's Good For The Game

The server is getting rid of many of the progress-loss features the codebase once had, and I think this is appropriate for that direction. The possibility of losing 10+ hours of XP after losing a fight might have suited what the original server was going for, but not this one, and it's not practical to effectively moderate every single use. 
This may even make diablerie more appealing, now that you're not causing a significant blow to an actual players's progress. Being evil is fun when characters suffer, not when _people_ lose a major chunk of XP through potentially no fault of their own.

## Changelog
:cl:
balance: Diablerie no longer affects the victim's generation. Failed diablerie raises the attacker's generation by 1.
balance: Diablerie will only lower your generation by 1, or by 2 if the victim is 4 or more generations below you.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
