### PR TITLE
Radios will now work between most zones

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -288,7 +288,10 @@
 	// Okay, the signal was never processed, send a mundane broadcast.
 	signal.data["compression"] = 0
 	signal.transmission_method = TRANSMISSION_RADIO
-	signal.levels = list(T.z)
+
+	//WoD13 edit! We want the radio to reach most of the z-levels, not just the one it's on.
+	//Ugly hardcoding; z-level 1 is the splashscreen (no signal), 2 is sewers (no signal), 3 is city, 4 is upper floors, 5 is special, 6 is Penumbra (no signal)
+	signal.levels = list(2, 3, 4, 5)
 	signal.broadcast()
 
 /obj/item/radio/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, list/message_mods = list())

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -290,7 +290,7 @@
 	signal.transmission_method = TRANSMISSION_RADIO
 
 	//WoD13 edit! We want the radio to reach most of the z-levels, not just the one it's on.
-	//Ugly hardcoding; z-level 1 is the splashscreen (no signal), 2 is sewers (no signal), 3 is city, 4 is upper floors, 5 is special, 6 is Penumbra (no signal)
+	//Ugly hardcoding; z-level 1 is the splashscreen (no signal), 2 is sewers, 3 is city, 4 is upper floors, 5 is special, 6 is Penumbra (no signal)
 	signal.levels = list(2, 3, 4, 5)
 	signal.broadcast()
 


### PR DESCRIPTION
Except inside Penumbra.
This is so that going up a building's roof does not completely bust your radio signal to the Camarilla prince.
Not sure if there's a better way to code it without hardcoding the specific z-level values on which the levels are on.