### PR TITLE
Removes extra empty z-levels being generated

### DIFF
--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -19,8 +19,8 @@
 	var/map_file = "MetaStation.dmm"
 
 	var/traits = null
-	var/space_ruin_levels = 7
-	var/space_empty_levels = 1
+	var/space_ruin_levels = 0
+	var/space_empty_levels = 0
 
 	var/minetype = "lavaland"
 


### PR DESCRIPTION
Up to 8 empty z-levels are accidentally created. This disables them.