### PR TITLE
Properly disables Saulocept from appearing

### DIFF
--- a/code/modules/vtmb/artifacts.dm
+++ b/code/modules/vtmb/artifacts.dm
@@ -233,8 +233,11 @@
 
 /obj/item/vtm_artifact/rand/Initialize()
 	. = ..()
-	var/spawnprobability = 0.5 //setting spawn probability of artifacts
-	if (rand() < spawnprobability) //generates a number between 0 and 1, if it's greater than .5, then we execute the next step
-		var/spawn_artifact = pick(/obj/item/vtm_artifact/odious_chalice, /obj/item/vtm_artifact/key_of_alamut, /obj/item/vtm_artifact/daimonori, /obj/item/vtm_artifact/bloodstar, /obj/item/vtm_artifact/heart_of_eliza, /obj/item/vtm_artifact/fae_charm, /obj/item/vtm_artifact/galdjum, /obj/item/vtm_artifact/saulocept, /obj/item/vtm_artifact/mummywrap_fetish, /obj/item/vtm_artifact/weekapaug_thistle)
+	if (prob(50)) //50% chance of spawning something
+		var/spawn_artifact = pick(/obj/item/vtm_artifact/odious_chalice, /obj/item/vtm_artifact/key_of_alamut,
+									/obj/item/vtm_artifact/daimonori, /obj/item/vtm_artifact/bloodstar,
+									/obj/item/vtm_artifact/heart_of_eliza, /obj/item/vtm_artifact/fae_charm,
+									/obj/item/vtm_artifact/galdjum, /obj/item/vtm_artifact/mummywrap_fetish,
+									/obj/item/vtm_artifact/weekapaug_thistle)
 		new spawn_artifact(loc)
 	qdel(src)


### PR DESCRIPTION
Its effects have been disabled in a direct server update/commit, this properly disables it from the list of artifacts that can appear.
Also fixed a bug where the actual probability of an artifact spawning was lower than intended, having anywhere from a 45% to a 49% chance to spawn instead of the intended 50% chance to spawn.