### PR TITLE
Makes Curse an actual curse

### DIFF
--- a/code/modules/vtmb/magic/pyramid.dm
+++ b/code/modules/vtmb/magic/pyramid.dm
@@ -361,7 +361,7 @@
 			cursed = namem
 			for(var/mob/living/carbon/human/H in GLOB.player_list)
 				if(H.real_name == cursed)
-					H.adjustCloneLoss(60)
+					H.adjustCloneLoss(25)
 					playsound(H.loc, 'code/modules/wod13/sounds/thaum.ogg', 50, FALSE)
 					to_chat(H, "<span class='warning'>You feel someone repeating your name from the shadows...</span>")
 					H.Stun(10)

--- a/code/modules/vtmb/magic/pyramid.dm
+++ b/code/modules/vtmb/magic/pyramid.dm
@@ -361,7 +361,7 @@
 			cursed = namem
 			for(var/mob/living/carbon/human/H in GLOB.player_list)
 				if(H.real_name == cursed)
-					H.adjustFireLoss(35)
+					H.adjustCloneLoss(60)
 					playsound(H.loc, 'code/modules/wod13/sounds/thaum.ogg', 50, FALSE)
 					to_chat(H, "<span class='warning'>You feel someone repeating your name from the shadows...</span>")
 					H.Stun(10)


### PR DESCRIPTION
## About The Pull Request
In the context of roleplay, Clan Tremere is not a fun experience. They inherently lack any niche or the ability to be feared as they are in lore. Giovanni/Cappadocians/Kiasyd can summon ghosts and Tremere can as well, and Lasombra get more utility out of their shadow magics so with that said, to give the Camarilla something to make people fear Clan Tremere.

I have swapped damage types from fire (which can easily be bloodhealed I would add) to aggravated damage. The damage might need to be scaled down post-generation nerf but I think its a good start to let Tremere Do Their Thing.

## Why It's Good For The Game
Mentioned Above

## Changelog
:cl:
Makes curse deal cloneloss damage.
/:cl:
