### PR TITLE
Potence nerf and an unarmed combat change

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -98,8 +98,6 @@ GLOBAL_LIST_EMPTY(selectable_races)
 	var/punchdamagelow = 1
 	///Highest possible punch damage this species can give.
 	var/punchdamagehigh = 10
-	///Damage at which punches from this race will stun
-	// var/punchstunthreshold = 20 //yes it should be to the attacked race but it's not useful that way even if it's logical
 	///Base electrocution coefficient.  Basically a multiplier for damage from electrocutions.
 	var/meleemod = 1
 	//For melee damage
@@ -1432,14 +1430,6 @@ GLOBAL_LIST_EMPTY(selectable_races)
 			target.apply_damage(damage, user.dna.species.attack_type, affecting, armor_block)
 			target.apply_damage(damage*1.5, STAMINA, affecting, armor_block)
 			log_combat(user, target, "punched")
-
-		///// WoD13 edit; punchstunthreshold variable on species was commented out.
-		// if((target.stat != DEAD) && damage >= user.dna.species.punchstunthreshold)
-		// 	target.visible_message("<span class='danger'>[user] knocks [target] down!</span>", "<span class='userdanger'>You're knocked down by [user]!</span>", "<span class='hear'>You hear aggressive shuffling followed by a loud thud!</span>", COMBAT_MESSAGE_RANGE, user)
-		// 	to_chat(user, "<span class='danger'>You knock [target] down!</span>")
-		// 	var/knockdown_duration = 40 + (target.getStaminaLoss() + (target.getBruteLoss()*0.5))*0.8 //50 total damage = 40 base stun + 40 stun modifier = 80 stun duration, which is the old base duration
-		// 	target.apply_effect(knockdown_duration, EFFECT_KNOCKDOWN, armor_block)
-		// 	log_combat(user, target, "got a stun punch with their previous punch")
 
 /datum/species/proc/spec_unarmedattacked(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	return

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1415,7 +1415,7 @@ GLOBAL_LIST_EMPTY(selectable_races)
 
 		if(user.potential >= 5)
 			var/atom/throw_target = get_edge_target_turf(target, user.dir)
-			target.throw_at(throw_target, rand(5, 7), 4, user)
+			target.throw_at(throw_target, rand(5, 7), 4, user, gentle = TRUE) //No stun nor impact damage from throwing people around
 
 		target.lastattacker = user.real_name
 		target.lastattackerckey = user.ckey

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1430,6 +1430,17 @@ GLOBAL_LIST_EMPTY(selectable_races)
 			target.apply_damage(damage, user.dna.species.attack_type, affecting, armor_block)
 			target.apply_damage(damage*1.5, STAMINA, affecting, armor_block)
 			log_combat(user, target, "punched")
+		//Punches have a chance (by default 10%, up to 30%) to knock down a target for about 2 seconds depending on physique and dexterity.
+		//Checks if the target is already knocked down to prevent stunlocking.
+		if((target.stat != DEAD) && (!target.IsKnockdown()))
+			//Compare puncher's physique to the greater between the target's physique (robust enough to tank it) or dexterity (rolls with the punches)
+			var/modifier = clamp(user.get_total_physique() - max(target.get_total_physique(), target.get_total_dexterity()), 1, 3)
+			if(storyteller_roll(difficulty = 10 - modifier) == ROLL_SUCCESS)
+				target.visible_message("<span class='danger'>[user] knocks [target] down!</span>", "<span class='userdanger'>You're knocked down by [user]!</span>", "<span class='hear'>You hear aggressive shuffling followed by a loud thud!</span>", COMBAT_MESSAGE_RANGE, user)
+				to_chat(user, "<span class='danger'>You knock [target] down!</span>")
+				target.apply_effect(2 SECONDS, EFFECT_KNOCKDOWN, armor_block)
+				log_combat(user, target, "got a stun punch with their previous punch")
+
 
 /datum/species/proc/spec_unarmedattacked(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	return

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1435,8 +1435,7 @@ GLOBAL_LIST_EMPTY(selectable_races)
 
 		///// WoD13 edit; punchstunthreshold variable on species was commented out.
 		// if((target.stat != DEAD) && damage >= user.dna.species.punchstunthreshold)
-		// 	target.visible_message("<span class='danger'>[user] knocks [target] down!</span>", \
-		// 					"<span class='userdanger'>You're knocked down by [user]!</span>", "<span class='hear'>You hear aggressive shuffling followed by a loud thud!</span>", COMBAT_MESSAGE_RANGE, user)
+		// 	target.visible_message("<span class='danger'>[user] knocks [target] down!</span>", "<span class='userdanger'>You're knocked down by [user]!</span>", "<span class='hear'>You hear aggressive shuffling followed by a loud thud!</span>", COMBAT_MESSAGE_RANGE, user)
 		// 	to_chat(user, "<span class='danger'>You knock [target] down!</span>")
 		// 	var/knockdown_duration = 40 + (target.getStaminaLoss() + (target.getBruteLoss()*0.5))*0.8 //50 total damage = 40 base stun + 40 stun modifier = 80 stun duration, which is the old base duration
 		// 	target.apply_effect(knockdown_duration, EFFECT_KNOCKDOWN, armor_block)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -99,7 +99,7 @@ GLOBAL_LIST_EMPTY(selectable_races)
 	///Highest possible punch damage this species can give.
 	var/punchdamagehigh = 10
 	///Damage at which punches from this race will stun
-	var/punchstunthreshold = 20 //yes it should be to the attacked race but it's not useful that way even if it's logical
+	// var/punchstunthreshold = 20 //yes it should be to the attacked race but it's not useful that way even if it's logical
 	///Base electrocution coefficient.  Basically a multiplier for damage from electrocutions.
 	var/meleemod = 1
 	//For melee damage
@@ -1433,13 +1433,14 @@ GLOBAL_LIST_EMPTY(selectable_races)
 			target.apply_damage(damage*1.5, STAMINA, affecting, armor_block)
 			log_combat(user, target, "punched")
 
-		if((target.stat != DEAD) && damage >= user.dna.species.punchstunthreshold)
-			target.visible_message("<span class='danger'>[user] knocks [target] down!</span>", \
-							"<span class='userdanger'>You're knocked down by [user]!</span>", "<span class='hear'>You hear aggressive shuffling followed by a loud thud!</span>", COMBAT_MESSAGE_RANGE, user)
-			to_chat(user, "<span class='danger'>You knock [target] down!</span>")
-			var/knockdown_duration = 40 + (target.getStaminaLoss() + (target.getBruteLoss()*0.5))*0.8 //50 total damage = 40 base stun + 40 stun modifier = 80 stun duration, which is the old base duration
-			target.apply_effect(knockdown_duration, EFFECT_KNOCKDOWN, armor_block)
-			log_combat(user, target, "got a stun punch with their previous punch")
+		///// WoD13 edit; punchstunthreshold variable on species was commented out.
+		// if((target.stat != DEAD) && damage >= user.dna.species.punchstunthreshold)
+		// 	target.visible_message("<span class='danger'>[user] knocks [target] down!</span>", \
+		// 					"<span class='userdanger'>You're knocked down by [user]!</span>", "<span class='hear'>You hear aggressive shuffling followed by a loud thud!</span>", COMBAT_MESSAGE_RANGE, user)
+		// 	to_chat(user, "<span class='danger'>You knock [target] down!</span>")
+		// 	var/knockdown_duration = 40 + (target.getStaminaLoss() + (target.getBruteLoss()*0.5))*0.8 //50 total damage = 40 base stun + 40 stun modifier = 80 stun duration, which is the old base duration
+		// 	target.apply_effect(knockdown_duration, EFFECT_KNOCKDOWN, armor_block)
+		// 	log_combat(user, target, "got a stun punch with their previous punch")
 
 /datum/species/proc/spec_unarmedattacked(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	return

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -12,7 +12,6 @@
 	siemens_coeff = 0
 	punchdamagelow = 5
 	punchdamagehigh = 14
-	// punchstunthreshold = 11 //about 40% chance to stun
 	no_equip = list(ITEM_SLOT_MASK, ITEM_SLOT_OCLOTHING, ITEM_SLOT_GLOVES, ITEM_SLOT_FEET, ITEM_SLOT_ICLOTHING, ITEM_SLOT_SUITSTORE)
 	nojumpsuit = 1
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC
@@ -168,7 +167,6 @@
 	name = "Silver Golem"
 	id = "silver golem"
 	fixed_mut_color = "ddd"
-	// punchstunthreshold = 9 //60% chance, from 40%
 	meat = /obj/item/stack/ore/silver
 	info_text = "As a <span class='danger'>Silver Golem</span>, your attacks have a higher chance of stunning. Being made of silver, your body is immune to most types of magic."
 	prefix = "Silver"
@@ -190,7 +188,6 @@
 	stunmod = 0.4
 	punchdamagelow = 12
 	punchdamagehigh = 21
-	// punchstunthreshold = 18 //still 40% stun chance
 	speedmod = 4 //pretty fucking slow
 	meat = /obj/item/stack/ore/iron
 	info_text = "As a <span class='danger'>Plasteel Golem</span>, you are slower, but harder to stun, and hit very hard when punching. You also magnetically attach to surfaces and so don't float without gravity and cannot have positions swapped with other beings."
@@ -328,7 +325,6 @@
 	brutemod = 0.5
 	punchdamagelow = 1
 	punchdamagehigh = 10
-	// punchstunthreshold = 9
 	prefix = "Uranium"
 	special_names = list("Oxide", "Rod", "Meltdown", "235")
 	COOLDOWN_DECLARE(radiation_emission_cooldown)
@@ -548,7 +544,6 @@
 	)
 	punchdamagelow = 0
 	punchdamagehigh = 1
-	// punchstunthreshold = 2 //Harmless and can't stun
 	meat = /obj/item/stack/ore/bananium
 	info_text = "As a <span class='danger'>Bananium Golem</span>, you are made for pranking. Your body emits natural honks, and you can barely even hurt people when punching them. Your skin also bleeds banana peels when damaged."
 	attack_verb = "honk"
@@ -697,7 +692,6 @@
 	burnmod = 2 // don't get burned
 	speedmod = 1 // not as heavy as stone
 	punchdamagelow = 4
-	// punchstunthreshold = 7
 	punchdamagehigh = 8 // not as heavy as stone
 	prefix = "Cloth"
 	special_names = null
@@ -901,7 +895,6 @@
 	heatmod = 2
 	speedmod = 1.5
 	punchdamagelow = 4
-	// punchstunthreshold = 7
 	punchdamagehigh = 8
 	var/last_creation = 0
 	var/brother_creation_cooldown = 300

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -12,7 +12,7 @@
 	siemens_coeff = 0
 	punchdamagelow = 5
 	punchdamagehigh = 14
-	punchstunthreshold = 11 //about 40% chance to stun
+	// punchstunthreshold = 11 //about 40% chance to stun
 	no_equip = list(ITEM_SLOT_MASK, ITEM_SLOT_OCLOTHING, ITEM_SLOT_GLOVES, ITEM_SLOT_FEET, ITEM_SLOT_ICLOTHING, ITEM_SLOT_SUITSTORE)
 	nojumpsuit = 1
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC
@@ -168,7 +168,7 @@
 	name = "Silver Golem"
 	id = "silver golem"
 	fixed_mut_color = "ddd"
-	punchstunthreshold = 9 //60% chance, from 40%
+	// punchstunthreshold = 9 //60% chance, from 40%
 	meat = /obj/item/stack/ore/silver
 	info_text = "As a <span class='danger'>Silver Golem</span>, your attacks have a higher chance of stunning. Being made of silver, your body is immune to most types of magic."
 	prefix = "Silver"
@@ -190,7 +190,7 @@
 	stunmod = 0.4
 	punchdamagelow = 12
 	punchdamagehigh = 21
-	punchstunthreshold = 18 //still 40% stun chance
+	// punchstunthreshold = 18 //still 40% stun chance
 	speedmod = 4 //pretty fucking slow
 	meat = /obj/item/stack/ore/iron
 	info_text = "As a <span class='danger'>Plasteel Golem</span>, you are slower, but harder to stun, and hit very hard when punching. You also magnetically attach to surfaces and so don't float without gravity and cannot have positions swapped with other beings."
@@ -328,7 +328,7 @@
 	brutemod = 0.5
 	punchdamagelow = 1
 	punchdamagehigh = 10
-	punchstunthreshold = 9
+	// punchstunthreshold = 9
 	prefix = "Uranium"
 	special_names = list("Oxide", "Rod", "Meltdown", "235")
 	COOLDOWN_DECLARE(radiation_emission_cooldown)
@@ -548,7 +548,7 @@
 	)
 	punchdamagelow = 0
 	punchdamagehigh = 1
-	punchstunthreshold = 2 //Harmless and can't stun
+	// punchstunthreshold = 2 //Harmless and can't stun
 	meat = /obj/item/stack/ore/bananium
 	info_text = "As a <span class='danger'>Bananium Golem</span>, you are made for pranking. Your body emits natural honks, and you can barely even hurt people when punching them. Your skin also bleeds banana peels when damaged."
 	attack_verb = "honk"
@@ -697,7 +697,7 @@
 	burnmod = 2 // don't get burned
 	speedmod = 1 // not as heavy as stone
 	punchdamagelow = 4
-	punchstunthreshold = 7
+	// punchstunthreshold = 7
 	punchdamagehigh = 8 // not as heavy as stone
 	prefix = "Cloth"
 	special_names = null
@@ -901,7 +901,7 @@
 	heatmod = 2
 	speedmod = 1.5
 	punchdamagelow = 4
-	punchstunthreshold = 7
+	// punchstunthreshold = 7
 	punchdamagehigh = 8
 	var/last_creation = 0
 	var/brother_creation_cooldown = 300

--- a/code/modules/mob/living/carbon/human/species_types/monkeys.dm
+++ b/code/modules/mob/living/carbon/human/species_types/monkeys.dm
@@ -20,7 +20,6 @@
 	sexes = FALSE
 	punchdamagelow = 1
 	punchdamagehigh = 3
-	// punchstunthreshold = 4 // no stun punches
 	species_language_holder = /datum/language_holder/monkey
 	bodypart_overides = list(
 	BODY_ZONE_L_ARM = /obj/item/bodypart/l_arm/monkey,\

--- a/code/modules/mob/living/carbon/human/species_types/monkeys.dm
+++ b/code/modules/mob/living/carbon/human/species_types/monkeys.dm
@@ -20,7 +20,7 @@
 	sexes = FALSE
 	punchdamagelow = 1
 	punchdamagehigh = 3
-	punchstunthreshold = 4 // no stun punches
+	// punchstunthreshold = 4 // no stun punches
 	species_language_holder = /datum/language_holder/monkey
 	bodypart_overides = list(
 	BODY_ZONE_L_ARM = /obj/item/bodypart/l_arm/monkey,\

--- a/code/modules/mob/living/carbon/human/species_types/mushpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mushpeople.dm
@@ -16,7 +16,6 @@
 
 	punchdamagelow = 6
 	punchdamagehigh = 14
-	// punchstunthreshold = 14 //about 44% chance to stun
 
 	no_equip = list(ITEM_SLOT_MASK, ITEM_SLOT_OCLOTHING, ITEM_SLOT_GLOVES, ITEM_SLOT_FEET, ITEM_SLOT_ICLOTHING)
 

--- a/code/modules/mob/living/carbon/human/species_types/mushpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mushpeople.dm
@@ -16,7 +16,7 @@
 
 	punchdamagelow = 6
 	punchdamagehigh = 14
-	punchstunthreshold = 14 //about 44% chance to stun
+	// punchstunthreshold = 14 //about 44% chance to stun
 
 	no_equip = list(ITEM_SLOT_MASK, ITEM_SLOT_OCLOTHING, ITEM_SLOT_GLOVES, ITEM_SLOT_FEET, ITEM_SLOT_ICLOTHING)
 

--- a/code/modules/mob/living/carbon/human/species_types/synths.dm
+++ b/code/modules/mob/living/carbon/human/species_types/synths.dm
@@ -28,7 +28,6 @@
 	armor = 25
 	punchdamagelow = 10
 	punchdamagehigh = 19
-	// punchstunthreshold = 14 //about 50% chance to stun
 	disguise_fail_health = 50
 	changesource_flags = MIRROR_BADMIN | WABBAJACK
 

--- a/code/modules/mob/living/carbon/human/species_types/synths.dm
+++ b/code/modules/mob/living/carbon/human/species_types/synths.dm
@@ -28,7 +28,7 @@
 	armor = 25
 	punchdamagelow = 10
 	punchdamagehigh = 19
-	punchstunthreshold = 14 //about 50% chance to stun
+	// punchstunthreshold = 14 //about 50% chance to stun
 	disguise_fail_health = 50
 	changesource_flags = MIRROR_BADMIN | WABBAJACK
 

--- a/code/modules/wod13/mannequin.dm
+++ b/code/modules/wod13/mannequin.dm
@@ -8,7 +8,6 @@
 	siemens_coeff = 0
 	punchdamagelow = 5
 	punchdamagehigh = 5
-	// punchstunthreshold = 0 //about 40% chance to stun
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC
 	damage_overlay_type = ""
 	meat = /obj/item/food/meat/slab/human/mutant/golem

--- a/code/modules/wod13/mannequin.dm
+++ b/code/modules/wod13/mannequin.dm
@@ -8,7 +8,7 @@
 	siemens_coeff = 0
 	punchdamagelow = 5
 	punchdamagehigh = 5
-	punchstunthreshold = 0 //about 40% chance to stun
+	// punchstunthreshold = 0 //about 40% chance to stun
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC
 	damage_overlay_type = ""
 	meat = /obj/item/food/meat/slab/human/mutant/golem


### PR DESCRIPTION
Revival of #397 , this PR does two things:
1. It toggles the "gentle" variable to Potence's throw_impact, which disables damage and stuns taken from colliding with other things such as walls.
2. It reworks the punching knockdown system. Previously you needed Potence to have a chance to knock someone down (until higher levels of Potence would just be guaranteed to knock down and stunlock), now punching has a 10% chance per punch to knock someone down for 2 seconds, which increases up to 30% per punch depending on the difference between the puncher's physique and whichever is greater of the target's physique or dexterity. The difference for the stun chance increase has to be at least 2 (example: user's physique of 5 vs target's physique and dexterity of 3, which increases the stun chance to 20%). 

I don't like how unatomic the PR has become.