### PR TITLE
Fixes Auspex not actually seeing in the dark

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -714,6 +714,10 @@
 		sight |= (SEE_TURFS|SEE_MOBS|SEE_OBJS)
 		see_in_dark = max(see_in_dark, 8)
 
+	if(HAS_TRAIT(src, TRAIT_NIGHT_VISION))
+		lighting_alpha = min(lighting_alpha, LIGHTING_PLANE_ALPHA_NV_TRAIT)
+		see_in_dark = max(see_in_dark, 8)
+
 	if(see_override)
 		see_invisible = see_override
 	. = ..()


### PR DESCRIPTION
It couldn't actually see in the dark because the "see_in_dark" variable was untouched, and it determines the distance after which tiles are completely invisible and unobservable by the mob if they're dark enough. This fixes it by adding actual behavior to TRAIT_NIGHT_VISION beyond just adding a very thin layer of visibility for tiles that are revealed in the dark while spawning eyes inside the player's head, so now you can actually see what's in the sewers.

Might make Auspex brighter after this PR.