### PR TITLE
New Admin Verb to Change the Global Masquerade(So admins can't accidentally freeze it by doing manually), Fixes Masquerade going over 1000

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -481,14 +481,13 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 	var/value = input(usr, "Enter the Global Masquerade adjustment values(- will decrease, + will increase) :", "Global Masquerade Adjustment", 0) as num|null
 	if(!value)
 		return
-
+	
 	SSmasquerade.manual_adjustment += value
-	
-	
+
 	SSmasquerade.fire()
 	
-	var/msg = "<span class='adminnotice'><b>Global Masquerade Adjustment: [key_name_admin(usr)] has adjusted Global masquerade from [last_global_mask] to [SSmasquerade.total_level] with the value of :[SSmasquerade.manual_adjustment]</b></span>"
-	log_admin("Global MasqAdjust: [key_name(usr)] has adjusted Global masquerade from [last_global_mask] to [SSmasquerade.total_level] with the value of :[SSmasquerade.manual_adjustment]")
+	var/msg = "<span class='adminnotice'><b>Global Masquerade Adjustment: [key_name_admin(usr)] has adjusted Global masquerade from [last_global_mask] to [SSmasquerade.total_level] with the value of :[value]</b></span>"
+	log_admin("Global MasqAdjust: [key_name(usr)] has adjusted Global masquerade from [last_global_mask] to [SSmasquerade.total_level] with the value of :[value]")
 	message_admins(msg)
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Global Adjust Masquerade")
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -479,15 +479,17 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 	var/last_global_mask = SSmasquerade.total_level
 
 	var/value = input(usr, "Enter the Global Masquerade adjustment values(- will decrease, + will increase) :", "Global Masquerade Adjustment", 0) as num|null
-	if(!value)
+	if(value == null)
 		return
 	
-	SSmasquerade.manual_adjustment += value
+	SSmasquerade.manual_adjustment = value
+
+	var/changed_mask = max(0,min(1000,last_global_mask + value))
 
 	SSmasquerade.fire()
 	
-	var/msg = "<span class='adminnotice'><b>Global Masquerade Adjustment: [key_name_admin(usr)] has adjusted Global masquerade from [last_global_mask] to [SSmasquerade.total_level] with the value of :[value]</b></span>"
-	log_admin("Global MasqAdjust: [key_name(usr)] has adjusted Global masquerade from [last_global_mask] to [SSmasquerade.total_level] with the value of :[value]")
+	var/msg = "<span class='adminnotice'><b>Global Masquerade Adjustment: [key_name_admin(usr)] has adjusted Global masquerade from [last_global_mask] to [changed_mask] with the value of : [value]. Real Masquerade Value with the other possible variables : [SSmasquerade.total_level]</b></span>"
+	log_admin("Global MasqAdjust: [key_name(usr)] has adjusted Global masquerade from [last_global_mask] to [changed_mask] with the value of : [value]. Real Masquerade Value with the other possible variables : [SSmasquerade.total_level]")
 	message_admins(msg)
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Global Adjust Masquerade")
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -54,6 +54,7 @@ GLOBAL_PROTECT(admin_verbs_admin)
 	/client/proc/getcurrentlogs,		/*for accessing server logs for the current round*/
 	/client/proc/cmd_admin_subtle_message,	/*send a message to somebody as a 'voice in their head'*/
 	/client/proc/cmd_admin_adjust_masquerade, /*adjusts the masquerade level of a player*/
+	/client/proc/cmd_admin_global_adjust_masquerade, /*adjusts the global masquerade*/
 	/client/proc/cmd_admin_adjust_humanity, /*adjusts the humanity level of a player*/
 	/client/proc/cmd_admin_headset_message,	/*send a message to somebody through their headset as CentCom*/
 	/client/proc/cmd_admin_delete,		/*delete an instance/object/mob/etc*/
@@ -221,6 +222,7 @@ GLOBAL_LIST_INIT(admin_verbs_hideable, list(
 	/client/proc/toggle_view_range,
 	/client/proc/cmd_admin_subtle_message,
 	/client/proc/cmd_admin_adjust_masquerade,
+	/client/proc/cmd_admin_global_adjust_masquerade,
 	/client/proc/cmd_admin_adjust_humanity,
 	/client/proc/cmd_admin_headset_message,
 	/client/proc/cmd_admin_check_contents,
@@ -466,6 +468,33 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 	message_admins("[key_name_admin(usr)] toggled the round's canonicity. The round is [GLOB.canon_event ? "now canon." : "no longer canon."]")
 	log_admin("[key_name(usr)] toggled the round's canonicity. The round is [GLOB.canon_event ? "now canon." : "no longer canon."]")
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Toggle Canon") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+/client/proc/cmd_admin_global_adjust_masquerade()
+	set name = "Adjust Global Masquerade"
+	set category = "Admin"
+	if (!check_rights(R_ADMIN))
+		return
+
+
+	var/last_global_mask = SSmasquerade.total_level
+
+	var/value = input(usr, "Enter the Global Masquerade adjustment values(- will decrease, + will increase) :", "Global Masquerade Adjustment", 0) as num|null
+	if(!value)
+		return
+
+	SSmasquerade.manual_adjustment += value
+	
+	
+	SSmasquerade.fire()
+	
+	var/msg = "<span class='adminnotice'><b>Global Masquerade Adjustment: [key_name_admin(usr)] has adjusted Global masquerade from [last_global_mask] to [SSmasquerade.total_level] with the value of :[SSmasquerade.manual_adjustment]</b></span>"
+	log_admin("Global MasqAdjust: [key_name(usr)] has adjusted Global masquerade from [last_global_mask] to [SSmasquerade.total_level] with the value of :[SSmasquerade.manual_adjustment]")
+	message_admins(msg)
+	SSblackbox.record_feedback("tally", "admin_verb", 1, "Global Adjust Masquerade")
+
+
+
+
 
 /client/proc/cmd_admin_adjust_masquerade(mob/living/carbon/human/M in GLOB.player_list)
 	set name = "Adjust Masquerade"

--- a/code/modules/vtmb/gamemodes/masquerade.dm
+++ b/code/modules/vtmb/gamemodes/masquerade.dm
@@ -7,6 +7,7 @@ SUBSYSTEM_DEF(masquerade)
 	var/total_level = 1000
 	var/dead_level = 0
 	var/last_level = "stable"
+	var/manual_adjustment = 0 
 
 /datum/controller/subsystem/masquerade/proc/get_description()
 	switch(total_level)
@@ -27,7 +28,7 @@ SUBSYSTEM_DEF(masquerade)
 	if(length(GLOB.sabbatites))
 		sabbat = (2000/length(GLOB.player_list))*length(GLOB.sabbatites)
 
-	total_level = max(0, 1000+dead_level-masquerade_violators-sabbat)
+	total_level = max(0, min(1000, 1000 + dead_level + manual_adjustment - masquerade_violators - sabbat))
 
 	var/shit_happens = "stable"
 	switch(total_level)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

New admin verb for a better manupilation of the masquerade, now it is also triggering the subsystem effects correctly like the  npc SWAT getting called on all kindred once it hits <250, also the global messages about the masquerade.

Masquerade now can't go over 1000 too

## Why It's Good For The Game

Masquerade won't freeze anymore if an admin wishes to change, fixes it going 1000 and all effects trigger like it should.

## Changelog
:cl:
add: New admin Verb
fix: Masquerade going over 1000
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
