### PR TITLE
The Radioening

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -11,7 +11,7 @@
 	dog_fashion = /datum/dog_fashion/back
 
 	flags_1 = CONDUCT_1 | HEAR_1
-	slot_flags = ITEM_SLOT_BELT
+	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_NECK // You can now clip a radio on your neck! Truly the future
 	throw_speed = 3
 	throw_range = 7
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/modules/vtmb/jobs/anarchs/baron.dm
+++ b/code/modules/vtmb/jobs/anarchs/baron.dm
@@ -43,7 +43,7 @@
 	gloves = /obj/item/clothing/gloves/vampire/work
 	l_pocket = /obj/item/vamp/phone/barkeeper
 	r_pocket = /obj/item/vamp/keys/bar
-	backpack_contents = list(/obj/item/passport=1, /obj/item/phone_book=1, /obj/item/cockclock=1, /obj/item/flashlight=1, /obj/item/vamp/creditcard=1)
+	backpack_contents = list(/obj/item/passport=1, /obj/item/phone_book=1, /obj/item/radio=1, /obj/item/cockclock=1, /obj/item/flashlight=1, /obj/item/vamp/creditcard=1)
 
 /datum/outfit/job/barkeeper/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/vtmb/jobs/anarchs/bouncer.dm
+++ b/code/modules/vtmb/jobs/anarchs/bouncer.dm
@@ -37,7 +37,7 @@
 	r_pocket = /obj/item/vamp/keys/anarch
 	l_pocket = /obj/item/vamp/phone/anarch
 	r_hand = /obj/item/melee/vampirearms/baseball
-	backpack_contents = list(/obj/item/passport=1, /obj/item/cockclock=1, /obj/item/vampire_stake=3, /obj/item/flashlight=1, /obj/item/vamp/keys/hack=1, /obj/item/vamp/creditcard=1)
+	backpack_contents = list(/obj/item/passport=1, /obj/item/cockclock=1, /obj/item/radio=1, /obj/item/vampire_stake=3, /obj/item/flashlight=1, /obj/item/vamp/keys/hack=1, /obj/item/vamp/creditcard=1)
 
 /datum/outfit/job/bruiser/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/vtmb/jobs/anarchs/emissary.dm
+++ b/code/modules/vtmb/jobs/anarchs/emissary.dm
@@ -36,7 +36,7 @@
 	shoes = /obj/item/clothing/shoes/vampire/jackboots
 	r_pocket = /obj/item/vamp/keys/anarch
 	l_pocket = /obj/item/vamp/phone/anarch
-	backpack_contents = list(/obj/item/passport=1, /obj/item/cockclock=1, /obj/item/flashlight=1, /obj/item/vamp/keys/hack=1, /obj/item/vamp/creditcard/rich=1)
+	backpack_contents = list(/obj/item/passport=1, /obj/item/cockclock=1, /obj/item/flashlight=1, /obj/item/radio=1, /obj/item/vamp/keys/hack=1, /obj/item/vamp/creditcard/rich=1)
 
 /datum/outfit/job/emissary/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/vtmb/jobs/anarchs/sweeper.dm
+++ b/code/modules/vtmb/jobs/anarchs/sweeper.dm
@@ -36,7 +36,7 @@
 	shoes = /obj/item/clothing/shoes/vampire/jackboots
 	r_pocket = /obj/item/vamp/keys/anarch
 	l_pocket = /obj/item/vamp/phone/anarch
-	backpack_contents = list(/obj/item/passport=1, /obj/item/cockclock=1, /obj/item/flashlight=1, /obj/item/vamp/keys/hack=1, /obj/item/vamp/creditcard=1, /obj/item/binoculars = 1)
+	backpack_contents = list(/obj/item/passport=1, /obj/item/cockclock=1, /obj/item/radio=1, /obj/item/flashlight=1, /obj/item/vamp/keys/hack=1, /obj/item/vamp/creditcard=1, /obj/item/binoculars = 1)
 
 /datum/outfit/job/sweeper/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/vtmb/jobs/prince.dm
+++ b/code/modules/vtmb/jobs/prince.dm
@@ -58,7 +58,7 @@
 	shoes = /obj/item/clothing/shoes/vampire
 	l_pocket = /obj/item/vamp/phone/prince
 	r_pocket = /obj/item/vamp/keys/prince
-	backpack_contents = list(/obj/item/gun/ballistic/automatic/vampire/deagle=1, /obj/item/phone_book=1, /obj/item/passport=1, /obj/item/cockclock=1, /obj/item/flashlight=1, /obj/item/masquerade_contract=1, /obj/item/vamp/creditcard/prince=1)
+	backpack_contents = list(/obj/item/gun/ballistic/automatic/vampire/deagle=1, /obj/item/phone_book=1, /obj/item/radio=1, /obj/item/passport=1, /obj/item/cockclock=1, /obj/item/flashlight=1, /obj/item/masquerade_contract=1, /obj/item/vamp/creditcard/prince=1)
 
 
 	backpack = /obj/item/storage/backpack

--- a/code/modules/vtmb/jobs/scourge.dm
+++ b/code/modules/vtmb/jobs/scourge.dm
@@ -42,7 +42,7 @@
 	shoes = /obj/item/clothing/shoes/vampire
 	r_pocket = /obj/item/vamp/keys/camarilla
 	l_pocket = /obj/item/vamp/phone/camarilla
-	backpack_contents = list(/obj/item/passport=1, /obj/item/cockclock=1, /obj/item/vampire_stake=3, /obj/item/flashlight=1, /obj/item/masquerade_contract=1, /obj/item/vamp/keys/hack=1, /obj/item/vamp/creditcard=1)
+	backpack_contents = list(/obj/item/passport=1, /obj/item/cockclock=1, /obj/item/vampire_stake=3, /obj/item/flashlight=1, /obj/item/masquerade_contract=1, /obj/item/vamp/keys/hack=1, /obj/item/radio=1, /obj/item/vamp/creditcard=1)
 
 	backpack = /obj/item/storage/backpack
 	satchel = /obj/item/storage/backpack/satchel

--- a/code/modules/vtmb/jobs/seneschal.dm
+++ b/code/modules/vtmb/jobs/seneschal.dm
@@ -60,7 +60,7 @@
 //	head = /obj/item/clothing/head/hopcap
 	l_pocket = /obj/item/vamp/phone/clerk
 	r_pocket = /obj/item/vamp/keys/clerk
-	backpack_contents = list(/obj/item/passport=1, /obj/item/phone_book=1, /obj/item/cockclock=1, /obj/item/flashlight=1, /obj/item/vamp/creditcard/seneschal=1)
+	backpack_contents = list(/obj/item/passport=1, /obj/item/phone_book=1, /obj/item/cockclock=1, /obj/item/radio=1, /obj/item/flashlight=1, /obj/item/vamp/creditcard/seneschal=1)
 
 /datum/outfit/job/clerk/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/vtmb/jobs/sheriff.dm
+++ b/code/modules/vtmb/jobs/sheriff.dm
@@ -58,7 +58,7 @@
 	glasses = /obj/item/clothing/glasses/vampire/sun
 	r_pocket = /obj/item/vamp/keys/sheriff
 	l_pocket = /obj/item/vamp/phone/sheriff
-	backpack_contents = list(/obj/item/gun/ballistic/automatic/vampire/deagle=1, /obj/item/vampire_stake=3, /obj/item/passport=1, /obj/item/cockclock=1, /obj/item/flashlight=1, /obj/item/masquerade_contract=1, /obj/item/vamp/creditcard/elder=1)
+	backpack_contents = list(/obj/item/gun/ballistic/automatic/vampire/deagle=1, /obj/item/radio=1, /obj/item/vampire_stake=3, /obj/item/passport=1, /obj/item/cockclock=1, /obj/item/flashlight=1, /obj/item/masquerade_contract=1, /obj/item/vamp/creditcard/elder=1)
 
 	backpack = /obj/item/storage/backpack
 	satchel = /obj/item/storage/backpack/satchel

--- a/code/modules/wod13/cargo.dm
+++ b/code/modules/wod13/cargo.dm
@@ -5,6 +5,17 @@
 	contains = list(/obj/item/storage/box/handcuffs)
 	crate_name = "handcuff crate"
 
+/datum/supply_pack/vampire/radio
+	name = "Box of Radios"
+	desc = "Contains a box of radios."
+	cost = 150
+	contains = list(/obj/item/radio,
+					/obj/item/radio,
+					/obj/item/radio,
+					/obj/item/radio,
+					/obj/item/radio)
+	crate_name = "radio crate"
+
 /datum/supply_pack/vampire/fixing
 	name = "Fixing kit (wirecutters, lamps)"
 	desc = "Contains wirecutters, lamps and other stuff to restore light in the area."


### PR DESCRIPTION
## About The Pull Request

This PR makes it so the Camarilla and Anarchs get a radio they can use to communicate amongst each other to lessen communication issues between players that led to situations, like say, the wiping of the PD. Also this PR allows you to buy them from the Warehouse so the dealer has more stuff to do.

You can now clip your radio onto your neck clothes slot too!
![image](https://github.com/user-attachments/assets/aed491dd-581c-4438-be1e-9c3ece11e304)
No sprites have been added for it to look like the above but thats the reference.

## Why It's Good For The Game

Mentioned above

## Changelog
:cl:
Gives radios to sect roles
Gives the cargo terminal the ability to buy more radios.
Lets you place a radio along your neck so you can free up your waist/pocket slots!
/:cl:
