### PR TITLE
Hotfixes pt. 1

### DIFF
--- a/code/modules/vtmb/electronics/p25.dm
+++ b/code/modules/vtmb/electronics/p25.dm
@@ -515,6 +515,11 @@ GLOBAL_LIST_EMPTY(p25_radios)
 	if(!ismob(speaker))
 		return NONE
 
+	var/mob/living/L = speaker
+	if(istype(L))
+		if(L.stat > CONSCIOUS)
+			return NONE
+
 	if(!can_transmit(speaker))
 		return NONE
 

--- a/code/modules/vtmb/jobs/police.dm
+++ b/code/modules/vtmb/jobs/police.dm
@@ -37,9 +37,7 @@
 	gloves = /obj/item/cockclock
 	id = /obj/item/card/id/police
 	l_pocket = /obj/item/vamp/phone
-	r_pocket = /obj/item/radio/cop
-	l_hand = /obj/item/vamp/keys/police
-	r_hand = /obj/item/police_radio
+	r_pocket = /obj/item/vamp/keys/police
 	backpack_contents = list(/obj/item/passport=1, /obj/item/implant/radio=1, /obj/item/vamp/creditcard=1, /obj/item/ammo_box/vampire/c9mm = 1, /obj/item/restraints/handcuffs = 1,/obj/item/melee/classic_baton/vampire = 1, /obj/item/storage/firstaid/ifak = 1)
 
 /datum/job/vamp/police_sergeant
@@ -79,9 +77,7 @@
 	gloves = /obj/item/cockclock
 	id = /obj/item/card/id/police/sergeant
 	l_pocket = /obj/item/vamp/phone
-	r_pocket = /obj/item/radio/cop
-	l_hand = /obj/item/vamp/keys/police/secure
-	r_hand = /obj/item/police_radio
+	r_pocket = /obj/item/vamp/keys/police/secure
 	backpack_contents = list(/obj/item/passport=1, /obj/item/implant/radio=1, /obj/item/vamp/creditcard=1, /obj/item/ammo_box/vampire/c9mm = 1, /obj/item/restraints/handcuffs = 1,/obj/item/melee/classic_baton/vampire = 1, /obj/item/storage/firstaid/ifak = 1)
 
 /datum/job/vamp/police_chief
@@ -121,7 +117,5 @@
 	gloves = /obj/item/cockclock
 	id = /obj/item/card/id/police/chief
 	l_pocket = /obj/item/vamp/phone
-	r_pocket = /obj/item/radio/cop
-	l_hand = /obj/item/vamp/keys/police/secure/chief
-	r_hand = /obj/item/police_radio
+	r_pocket = /obj/item/vamp/keys/police/secure/chief
 	backpack_contents = list(/obj/item/passport=1, /obj/item/implant/radio=1, /obj/item/vamp/creditcard=1, /obj/item/ammo_box/vampire/c9mm = 1, /obj/item/restraints/handcuffs = 1,/obj/item/melee/classic_baton/vampire = 1, /obj/item/storage/firstaid/ifak = 1)

--- a/code/modules/wod13/food.dm
+++ b/code/modules/wod13/food.dm
@@ -592,7 +592,6 @@
 		new /datum/data/mining_equipment("crime scene tape", /obj/item/barrier_tape/police, 1),
 		new /datum/data/mining_equipment("body bags", /obj/item/storage/box/bodybags, 1),
 		new /datum/data/mining_equipment("police vest", /obj/item/clothing/suit/vampire/vest/police, 1),
-		new /datum/data/mining_equipment("police radio", /obj/item/radio/cop, 2),
 		new /datum/data/mining_equipment("police uniform", /obj/item/clothing/under/vampire/police, 1),
 		new /datum/data/mining_equipment("police hat", /obj/item/clothing/head/vampire/police, 1),
 		new /datum/data/mining_equipment("flashlight", /obj/item/flashlight, 1),


### PR DESCRIPTION

## About The Pull Request

dead can no longer speak in p25 anymore, police no longer spawn with outdated radios.

## Why It's Good For The Game

hotfixes, more coming soon

## Changelog
:cl:
fix: Dead can no longer speak through p25 radio; Police no longer spawn with outdated radios.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
