### PR TITLE
Click-dragging simple-mobs such as mice should now properly allow aggressive grabs

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -504,7 +504,7 @@
 	if(istype(ML))
 		ML.pulled(src)
 
-/mob/living/carbon/human/CtrlClick(mob/user)
+/mob/living/CtrlClick(mob/user)
 	if(ishuman(user) && Adjacent(user) && !user.incapacitated())
 		if(world.time < user.next_move)
 			return FALSE

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1339,12 +1339,14 @@ GLOBAL_LIST_EMPTY(selectable_races)
 	user.do_cpr(target)
 
 
-/datum/species/proc/grab(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)
-	if(target.check_block())
-		target.visible_message("<span class='warning'>[target] blocks [user]'s grab!</span>", \
-						"<span class='userdanger'>You block [user]'s grab!</span>", "<span class='hear'>You hear a swoosh!</span>", COMBAT_MESSAGE_RANGE, user)
-		to_chat(user, "<span class='warning'>Your grab at [target] was blocked!</span>")
-		return FALSE
+/datum/species/proc/grab(mob/living/carbon/human/user, mob/living/target, datum/martial_art/attacker_style)
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		if(H.check_block())
+			H.visible_message("<span class='warning'>[H] blocks [user]'s grab!</span>", \
+							"<span class='userdanger'>You block [user]'s grab!</span>", "<span class='hear'>You hear a swoosh!</span>", COMBAT_MESSAGE_RANGE, user)
+			to_chat(user, "<span class='warning'>Your grab at [H] was blocked!</span>")
+			return FALSE
 	if(attacker_style?.grab_act(user,target))
 		return TRUE
 	else

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1341,11 +1341,11 @@ GLOBAL_LIST_EMPTY(selectable_races)
 
 /datum/species/proc/grab(mob/living/carbon/human/user, mob/living/target, datum/martial_art/attacker_style)
 	if(ishuman(target))
-		var/mob/living/carbon/human/H = target
-		if(H.check_block())
-			H.visible_message("<span class='warning'>[H] blocks [user]'s grab!</span>", \
+		var/mob/living/carbon/human/human = target
+		if(human.check_block())
+			human.visible_message("<span class='warning'>[human] blocks [user]'s grab!</span>", \
 							"<span class='userdanger'>You block [user]'s grab!</span>", "<span class='hear'>You hear a swoosh!</span>", COMBAT_MESSAGE_RANGE, user)
-			to_chat(user, "<span class='warning'>Your grab at [H] was blocked!</span>")
+			to_chat(user, "<span class='warning'>Your grab at [human] was blocked!</span>")
 			return FALSE
 	if(attacker_style?.grab_act(user,target))
 		return TRUE


### PR DESCRIPTION
Problem: You can't ctrl+click on rats to put them in aggressive grab mode, you have to be on grab intent and to manually click them.
Solution: This PR.
Also relaxed a check so that it allowed for simple-mobs to be aggressive-grabbed through ctrl+click, this also means you can incorporate martial arts on simple-mobs via click-dragging rather than grab intent only.