### PR TITLE
Marks capture system

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -18,7 +18,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	"[FREQ_CTF_BLUE]" = "blueteamradio"
 	))
 
-/atom/movable/proc/say(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
+/atom/movable/proc/say(message, range = 7, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
 	if(!can_speak())
 		return
 	if(message == "" || !message)
@@ -26,7 +26,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	spans |= speech_span
 	if(!language)
 		language = get_selected_language()
-	send_speech(message, 7, src, , spans, message_language=language)
+	send_speech(message, range, src, , spans, message_language=language)
 
 /atom/movable/proc/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, list/message_mods = list())
 	SEND_SIGNAL(src, COMSIG_MOVABLE_HEAR, args)


### PR DESCRIPTION
## About The Pull Request

Marks capturing is made differently. You claim the mark, must be around for some time, and defend it against other factions. The rate is higher the more of your comrades and fewer enemies around. 

The message about assaults now comes to the phones of all vampiric factions. The mark progress is shown in the description.

## Why It's Good For The Game

It adds depth to the faction dynamics, changing how faction conflicts go. Where you aren't running and taking marks randomly. The new system is not forcing you to kill everyone in sight but to push them out and it praises you for interaction with others from your group.

## Changelog
:cl:
tweak: marks capture is made differently and longer.
/:cl: