### PR TITLE
Makes sorting and rolling weed 5x faster

### DIFF
--- a/code/modules/wod13/narco.dm
+++ b/code/modules/wod13/narco.dm
@@ -45,7 +45,7 @@
 
 /datum/crafting_recipe/weed_leaf
 	name = "Sort Weed"
-	time = 50
+	time = 10
 	reqs = list(/obj/item/food/vampire/weed = 1)
 	result = /obj/item/weedpack
 	always_available = TRUE
@@ -53,7 +53,7 @@
 
 /datum/crafting_recipe/weed_blunt
 	name = "Roll Blunt"
-	time = 50
+	time = 10
 	reqs = list(/obj/item/weedpack = 1, /obj/item/paper = 1)
 	result = /obj/item/clothing/mask/cigarette/rollie/cannabis
 	always_available = TRUE


### PR DESCRIPTION
Problem: Growing weed is a pretty bad alternative to just fishing. In fact, making drugs generally has a lot more problems than just fishing.
Partial solution: Shorten the time it takes to sort weed (and also make blunts) to just 1 second from 5.