### PR TITLE
Updates About Me for Garou

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -152,4 +152,7 @@
 	var/diablerist = FALSE
 	var/antifrenzy = FALSE
 
+	var/account_id //Making bank accounts work for Garou is a pain if this isn't defined here
+	var/bank_id
+
 	COOLDOWN_DECLARE(bleeding_message_cd)

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -64,8 +64,6 @@
 	var/static/list/can_ride_typecache = typecacheof(list(/mob/living/carbon/human, /mob/living/simple_animal/slime, /mob/living/simple_animal/parrot))
 	var/lastpuke = 0
 	var/last_fire_update
-	var/account_id
-	var/bank_id
 
 	var/hardcore_survival_score = 0
 	/// For agendered spessmen, which body type to use

--- a/code/modules/vtmb/werewolf_species.dm
+++ b/code/modules/vtmb/werewolf_species.dm
@@ -62,11 +62,13 @@
 				if(A.objectives)
 					dat += "[printobjectives(A.objectives)]<BR>"
 
-		dat += "<b>Physique</b>: [host.physique]<BR>"
-		dat += "<b>Dexterity</b>: [host.dexterity]<BR>"
-		dat += "<b>Social</b>: [host.social]<BR>"
-		dat += "<b>Mentality</b>: [host.mentality]<BR>"
-		dat += "<b>Cruelty</b>: [host.blood]<BR>"
+		dat += "<b>Physique</b>: [host.physique] + [host.additional_physique]<BR>"
+		dat += "<b>Dexterity</b>: [host.dexterity] + [host.additional_dexterity]<BR>"
+		dat += "<b>Social</b>: [host.social] + [host.additional_social]<BR>"
+		dat += "<b>Mentality</b>: [host.mentality] + [host.additional_mentality]<BR>"
+		dat += "<b>Cruelty</b>: [host.blood] + [host.additional_blood]<BR>"
+		dat += "<b>Lockpicking</b>: [host.lockpicking] + [host.additional_lockpicking]<BR>"
+		dat += "<b>Athletics</b>: [host.athletics] + [host.additional_athletics]<BR>"
 		if(host.Myself)
 			if(host.Myself.Friend)
 				if(host.Myself.Friend.owner)
@@ -91,6 +93,9 @@
 			dat += "<b>I know some other of my kind in this city. Need to check my phone, there definetely should be:</b><BR>"
 			for(var/i in host.knowscontacts)
 				dat += "-[i] contact<BR>"
+		for(var/datum/vtm_bank_account/account in GLOB.bank_account_list)
+			if(host.bank_id == account.bank_id)
+				dat += "<b>My bank account code is: [account.code]</b><BR>"
 		host << browse(dat, "window=vampire;size=400x450;border=1;can_resize=1;can_minimize=0")
 		onclose(host, "vampire", src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The About Me button is outdated for werewolves, and doesn't show Lockpicking/Athletics or the stat bonuses of archetypes. Likely due to the added complexity of the Garou species, they additionally would not be given their own ATM PIN, effectively making them completely broke. This fixes both.

## Why It's Good For The Game

The update to displaying stats is just a plain oversight fix.
The latter fix makes bank_id and account_id variables of mob/living/carbon and not just carbon/human, which I don't _believe_ will cause any issues. I didn't see any runtimes when spawning.

## Changelog
:cl:
fix: updated the About Me verb for Garou to correctly display your stats
fix: Garou are now correctly assigned a bank account PIN
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
