### PR TITLE
Make booze free

### DIFF
--- a/code/modules/vending/boozeomat.dm
+++ b/code/modules/vending/boozeomat.dm
@@ -63,6 +63,7 @@
 /obj/machinery/vending/boozeomat/all_access
 	desc = "A technological marvel, supposedly able to mix just the mixture you'd like to drink the moment you ask for one. This model appears to have no access restrictions."
 	req_access = null
+	onstation = FALSE
 
 /obj/machinery/vending/boozeomat/syndicate_access
 	req_access = list(ACCESS_SYNDICATE)


### PR DESCRIPTION
## About The Pull Request

It makes alcohol free in all boozeomats.

## Why It's Good For The Game

It was annoying to have access through id cards. Now it's convenient.

## Changelog
:cl:
tweak: boozeomat is free
/:cl:
