### PR TITLE
Injury slowdown will now scale with the user's max health

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1262,9 +1262,11 @@
 		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown_flying)
 		return
 	var/health_deficiency = max((maxHealth - health), staminaloss)
-	if(health_deficiency >= 40)
-		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown, TRUE, multiplicative_slowdown = health_deficiency / 75)
-		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown_flying, TRUE, multiplicative_slowdown = health_deficiency / 25)
+	var/health_scale_modifier = maxHealth/100 //If the human has a higher amount of max health this will be reflected in the amount of damage required to slow down.
+	var/health_slowdown = health_deficiency / (75 * health_scale_modifier)
+	if(health_deficiency >= (40 * health_scale_modifier))
+		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown, TRUE, multiplicative_slowdown = health_slowdown)
+		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown_flying, TRUE, multiplicative_slowdown = health_slowdown)
 	else
 		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown)
 		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown_flying)


### PR DESCRIPTION
This PR makes the movement slowdown scale with the user's max health, so that relatively minor injuries no longer slow down as hard as they should.
Obvious balance implications in the way that high-physique characters and lower-generation vampires can move during combat, however.
This also fixes a potential issue where high-health characters could be slowed down far more than lower-health characters because of how the slowdown calculation worked, which didn't scale with max health.