### PR TITLE
Readjusts values & lessens the amount of corpsed bodies

### DIFF
--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -3,7 +3,7 @@
 	icon_state = "ears"
 	desc = "There are three parts to the ear. Inner, middle and outer. Only one of these parts should be normally visible."
 	illegal = TRUE
-	cost = 300
+	cost = 100
 	zone = BODY_ZONE_HEAD
 	slot = ORGAN_SLOT_EARS
 	gender = PLURAL

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -3,7 +3,7 @@
 	icon_state = "eyeballs"
 	desc = "I see you!"
 	illegal = TRUE
-	cost = 300
+	cost = 100
 	zone = BODY_ZONE_PRECISE_EYES
 	slot = ORGAN_SLOT_EYES
 	gender = PLURAL

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -3,7 +3,7 @@
 	desc = "I feel bad for the heartless bastard who lost this."
 	icon_state = "heart-on"
 	illegal = TRUE
-	cost = 1500
+	cost = 750
 	zone = BODY_ZONE_CHEST
 	slot = ORGAN_SLOT_HEART
 

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -5,7 +5,7 @@
 	name = "liver"
 	icon_state = "liver"
 	illegal = TRUE
-	cost = 800
+	cost = 400
 	w_class = WEIGHT_CLASS_SMALL
 	zone = BODY_ZONE_CHEST
 	slot = ORGAN_SLOT_LIVER

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -4,7 +4,7 @@
 	name = "lungs"
 	icon_state = "lungs"
 	illegal = TRUE
-	cost = 800
+	cost = 450
 	zone = BODY_ZONE_CHEST
 	slot = ORGAN_SLOT_LUNGS
 	gender = PLURAL

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -5,7 +5,7 @@
 	name = "stomach"
 	icon_state = "stomach"
 	illegal = TRUE
-	cost = 300
+	cost = 100
 	w_class = WEIGHT_CLASS_SMALL
 	zone = BODY_ZONE_CHEST
 	slot = ORGAN_SLOT_STOMACH

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -3,7 +3,7 @@
 	desc = "A fleshy muscle mostly used for lying."
 	icon_state = "tonguenormal"
 	illegal = TRUE
-	cost = 200
+	cost = 100
 	zone = BODY_ZONE_PRECISE_MOUTH
 	slot = ORGAN_SLOT_TONGUE
 	attack_verb_continuous = list("licks", "slobbers", "slaps", "frenches", "tongues")

--- a/code/modules/wod13/food.dm
+++ b/code/modules/wod13/food.dm
@@ -526,13 +526,13 @@
 
 /obj/machinery/mineral/equipment_vendor/fastfood/illegal
 	prize_list = list(
-		new /datum/data/mining_equipment("morphine syringe",	/obj/item/reagent_containers/syringe/contraband/morphine,	100),
-		new	/datum/data/mining_equipment("meth package",	/obj/item/reagent_containers/food/drinks/meth,	300),
-		new	/datum/data/mining_equipment("cocaine package",	/obj/item/reagent_containers/food/drinks/meth/cocaine,	700),
+		new /datum/data/mining_equipment("morphine syringe",	/obj/item/reagent_containers/syringe/contraband/morphine,	800),
+		new	/datum/data/mining_equipment("meth package",	/obj/item/reagent_containers/food/drinks/meth,	800),
+		new	/datum/data/mining_equipment("cocaine package",	/obj/item/reagent_containers/food/drinks/meth/cocaine,	800),
 		new /datum/data/mining_equipment("LSD pill bottle",		/obj/item/storage/pill_bottle/lsd,	50),
 		new /datum/data/mining_equipment("LSD pill",		/obj/item/reagent_containers/pill/lsd,	10),
 		new /datum/data/mining_equipment("cannabis puff",		/obj/item/clothing/mask/cigarette/rollie/cannabis,	40),
-		new /datum/data/mining_equipment("cannabis package",		/obj/item/weedpack,	175),
+		new /datum/data/mining_equipment("cannabis package",		/obj/item/weedpack,	700),
 		new /datum/data/mining_equipment("cannabis seed",	/obj/item/weedseed,		10),
 		new /datum/data/mining_equipment("bong",	/obj/item/bong,		50),
 		new /datum/data/mining_equipment("snub-nose revolver",	/obj/item/gun/ballistic/vampire/revolver/snub,	100),

--- a/code/modules/wod13/narco.dm
+++ b/code/modules/wod13/narco.dm
@@ -71,7 +71,7 @@
 	food_reagents = list(/datum/reagent/drug/space_drugs = 20, /datum/reagent/toxin/lipolicide = 20)
 	eat_time = 10
 	illegal = TRUE
-	cost = 50
+	cost = 350
 
 /obj/item/bailer
 	name = "bailer"
@@ -541,13 +541,13 @@ SUBSYSTEM_DEF(smokeweedeveryday)
 	isGlass = FALSE
 	foodtype = BREAKFAST
 	illegal = TRUE
-	cost = 300
+	cost = 650
 
 /obj/item/reagent_containers/food/drinks/meth/cocaine
 	name = "white package"
 	icon_state = "package_cocaine"
 	list_reagents = list(/datum/reagent/drug/methamphetamine/cocaine = 30)
-	cost = 500
+	cost = 750
 
 /obj/item/reagent_containers/drug/methpack
 	name = "\improper elite blood pack (full)"

--- a/code/modules/wod13/narco.dm
+++ b/code/modules/wod13/narco.dm
@@ -41,7 +41,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
 	illegal = TRUE
-	cost = 175
+	cost = 550
 
 /datum/crafting_recipe/weed_leaf
 	name = "Sort Weed"


### PR DESCRIPTION
## About The Pull Request

The following pr makes it so the total cost of one NPC is roughly 2K if you trade in every single organ (Going by the cost = value). This PR also significantly buffs drug selling and weed trading as well! Encouraging players to set up farms and defend them as a means of establishing territory.

## Why It's Good For The Game

As mentioned above.

## Changelog
:cl:
Lowers the value of all organs to equal 2K.
Increases the value of weed to 350, meth to 650, and cocaine to 750.
/:cl:
