### PR TITLE
Auspex ghosts should no longer be polled for midround roles

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -416,7 +416,8 @@
 		return candidates
 
 	for(var/mob/dead/observer/G in GLOB.player_list)
-		candidates += G
+		if(!G.auspex_ghosted) //No Auspex ghosts as candidates.
+			candidates += G
 
 	return pollCandidates(Question, jobbanType, gametypeCheck, be_special_flag, poll_time, ignore_category, flashwindow, candidates)
 


### PR DESCRIPTION
This includes Question To Ancestors, summoning demons and creating gargoyles.
Why? Because Auspex ghosts aren't real ghosts! They aren't supposed to be polled for midround roles, and doing so prevents them from returning to their bodies.