### PR TITLE
Decrease Variation in Round-Start Account Balance

### DIFF
--- a/code/modules/vtmb/electronics/atms/atm.dm
+++ b/code/modules/vtmb/electronics/atms/atm.dm
@@ -103,7 +103,7 @@ var/mob/living/carbon/human/H
 	else if(istype(src, /obj/item/vamp/creditcard/seneschal))
 		account.balance = rand(4000, 8000)
 	else
-		account.balance = rand(300, 900)
+		account.balance = rand(600, 1000)
 
 /obj/machinery/vamp/atm/Initialize()
 	..()

--- a/code/modules/vtmb/electronics/atms/atm.dm
+++ b/code/modules/vtmb/electronics/atms/atm.dm
@@ -103,7 +103,7 @@ var/mob/living/carbon/human/H
 	else if(istype(src, /obj/item/vamp/creditcard/seneschal))
 		account.balance = rand(4000, 8000)
 	else
-		account.balance = rand(100, 1000)
+		account.balance = rand(300, 900)
 
 /obj/machinery/vamp/atm/Initialize()
 	..()


### PR DESCRIPTION

## About The Pull Request
Gives non-fabulously rich characters a little extra minimum money, in return for having a lower ceiling on how much they can have round-start.

## Why It's Good For The Game

Allows for buying fashion accessories at round start and other near-necessary items.
