### PR TITLE
Stopgap solution to Garou not getting ATM PINs

### DIFF
--- a/code/modules/vtmb/electronics/atms/atm.dm
+++ b/code/modules/vtmb/electronics/atms/atm.dm
@@ -88,6 +88,11 @@ var/mob/living/carbon/human/H
 
 /obj/item/vamp/creditcard/New(mob/user)
 	..()
+	if(isgarou(user))
+		var/obj/item/stack/dollar/allowance = new /obj/item/stack/dollar
+		user.put_in_hands(allowance)
+		allowance.amount = rand(100, 1000)
+		update_icon_state(allowance)
 	if(!account || code == "")
 		account = new /datum/vtm_bank_account()
 	if(user)

--- a/code/modules/vtmb/electronics/atms/atm.dm
+++ b/code/modules/vtmb/electronics/atms/atm.dm
@@ -93,6 +93,7 @@ var/mob/living/carbon/human/H
 		user.put_in_hands(allowance)
 		allowance.amount = rand(100, 1000)
 		update_icon_state(allowance)
+		qdel(src)
 	if(!account || code == "")
 		account = new /datum/vtm_bank_account()
 	if(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I put up #497 to update the About Me button for Garou to current standards + allow them to access their own bank accounts, but it was made shortly before the species code freeze and can't be merged. This is a short-term solution that causes their cards to disappear and places cash in their hand instead.

## Why It's Good For The Game

Garou currently effectively spawn with 0 dollars because they can't use their own bank account. This fixes that, and also makes IC sense for some werewolves who wouldn't necessarily have a bank account!

## Changelog
:cl:
tweak: garou now spawn with cash instead of a credit card that they can't use
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
