### PR TITLE
Fireman carry quick fix

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -769,7 +769,7 @@
 	for(var/m in buckled_mobs)
 		var/mob/living/buckled_mob = m
 		if(!buckled_mob.Move(newloc, direct, glide_size_override))
-			forceMove(buckled_mob.loc)
+			doMove(buckled_mob.loc) //forcemove has an override that breaks grabs and unbuckles, for some reason
 			last_move = buckled_mob.last_move
 			inertia_dir = last_move
 			buckled_mob.inertia_dir = last_move


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

The proc originally used to move mobs buckled to another for some reason broke grabs and unbuckled the mob from anything they were on, making fireman carries completely useless. I replaced it for the proc it would usually call right after unbuckling the mob

**However, this for some reason disables diagonal movement while carrying someone.** I didn't bother trying to find a way to safely use the proper movement functions

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


https://github.com/user-attachments/assets/8c25097d-ce45-43f9-b062-6e4e57fc89b5

## Changelog
:cl:
add: Fireman carry is fixed
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
