### PR TITLE
[HOTFIX] Nerfs crossbow damage and wound bonus into the fucking ground

### DIFF
--- a/code/modules/wod13/ammostack.dm
+++ b/code/modules/wod13/ammostack.dm
@@ -124,10 +124,9 @@
 
 /obj/projectile/bullet/crossbow_bolt
 	name = "bolt"
-	damage = 160
+	damage = 45
 	armour_penetration = 75
 	sharpness = SHARP_POINTY
-	wound_bonus = 50
 
 /obj/item/ammo_casing/vampire
 	icon = 'code/modules/wod13/ammo.dmi'


### PR DESCRIPTION
…GE???

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Why do these do 160 damage? Why did nobody report this in an issue?

Instead they keep their armor pen and lose the wound bonus because bullets already get a wound bonus that get buffed by cruelty as is.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

160? 160 damage? with 75 armor pen and +50 wound bonus? Crack? Is it crack? Are you smoking crack? Have you lost your mind? Because I'll help you find it.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Bisar
balance: Crossbows do a relatively reasonable amount of damage now (160??? 160??????? WHY?)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
