### PR TITLE
Changes the manifest Groupings

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -141,24 +141,26 @@
 
 /datum/datacore/proc/get_manifest()
 	var/list/manifest_out = list(
-		"Command",
-		"Security",
-		"Engineering",
-		"Medical",
-		"Science",
-		"Supply",
-		"Service",
-		"Silicon"
+ 		"Camarilla",
+		"Primogen Council",
+		"Tremere",
+		"Anarch",
+		"Giovanni",
+		"Old Clan Tzimisce",
+		"Law Enforcement",
+		"Warehouse",
+		"Triad"
 	)
 	var/list/departments = list(
-		"Command" = GLOB.command_positions,
-		"Security" = GLOB.ss13,
-		"Engineering" = GLOB.ss13,
-		"Medical" = GLOB.ss13,
-		"Science" = GLOB.anarch_positions,
-		"Supply" = GLOB.ss13,
-		"Service" = GLOB.neutral_positions,
-		"Silicon" = GLOB.nonhuman_positions
+		"Camarilla" = GLOB.command_positions,
+		"Primogen Council" = GLOB.camarilla_council_positions,
+		"Tremere" = GLOB.tremere_positions,
+		"Anarch" = GLOB.anarch_positions,
+		"Giovanni" = GLOB.giovanni_positions,
+		"Old Clan Tzimisce" = GLOB.tzimisce_positions,
+		"Law Enforcement" = GLOB.police_positions + GLOB.national_security_positions,
+		"Warehouse" = GLOB.warehouse_positions,
+		"Triad" = GLOB.gang_positions
 	)
 	for(var/datum/data/record/t in GLOB.data_core.general)
 		var/name = t.fields["name"]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The manifest will now list Camarilla, Primogen, Tremere, Anarch, Giovanni, Old Clan Tzimisce, Law Eforcement, Warehouse, Triad, and Misc, in that order.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It beats listing everything as either Command (Camarilla), Science (Anarch) or Misc.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The Manifest now actually uses our job groupings.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
