### PR TITLE
Adjusts drug money for a final time

### DIFF
--- a/code/modules/wod13/narco.dm
+++ b/code/modules/wod13/narco.dm
@@ -41,7 +41,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
 	illegal = TRUE
-	cost = 550
+	cost = 150
 
 /datum/crafting_recipe/weed_leaf
 	name = "Sort Weed"
@@ -71,7 +71,7 @@
 	food_reagents = list(/datum/reagent/drug/space_drugs = 20, /datum/reagent/toxin/lipolicide = 20)
 	eat_time = 10
 	illegal = TRUE
-	cost = 350
+	cost = 50
 
 /obj/item/bailer
 	name = "bailer"
@@ -542,13 +542,13 @@ SUBSYSTEM_DEF(smokeweedeveryday)
 	isGlass = FALSE
 	foodtype = BREAKFAST
 	illegal = TRUE
-	cost = 650
+	cost = 300
 
 /obj/item/reagent_containers/food/drinks/meth/cocaine
 	name = "white package"
 	icon_state = "package_cocaine"
 	list_reagents = list(/datum/reagent/drug/methamphetamine/cocaine = 30)
-	cost = 750
+	cost = 300
 
 /obj/item/reagent_containers/drug/methpack
 	name = "\improper elite blood pack (full)"

--- a/code/modules/wod13/narco.dm
+++ b/code/modules/wod13/narco.dm
@@ -509,7 +509,7 @@ SUBSYSTEM_DEF(smokeweedeveryday)
 				troll_explode = TRUE
 			if(!added_iod)
 				troll_explode = TRUE
-			G.stored_gasoline = max(0, G.stored_gasoline-50)
+			G.stored_gasoline = max(0, G.stored_gasoline-100)
 			playsound(loc, 'code/modules/wod13/sounds/gas_fill.ogg', 25, TRUE)
 			to_chat(user, "You [pick("spill", "add", "blender")] [used_item] in [src].")
 			added_gas = TRUE


### PR DESCRIPTION
## About The Pull Request

The original PR I made for this was a bit too overtuned; I've since rectified this with this PR here. Fewer people are of the dreaded "path of the organ harvester" so that worked at the very least! Anyway, heres the math:

350 x 4 (meth) for 1400, 
An epi bottle is 200 dollars (vendor price)
Potassium iodide is 100 (vendor price)
Gasoline canister is 250 (vendor price), but I misread the code, its now taking up 100 out of 1000 so you are really only going to get 10 batches of meth.

Adding it together, each batch at the cost they are sold for will yield a profit of 850 per batch and making 10 of it is 8500 but this requires significant cost investment, unlike weed which requires roughly 15 minutes to grow from round start.

150 for weed, previously 50. 
You'll generally hit 900 dollars if you get six leaves as a best case scenario from RNG (I might be wrong here), the benefit being that you can maintain this so long as you water the plants.

## Why It's Good For The Game

People had too much money and it was kind of crazy and I overdid some values, this accounts for 5 social however so do be aware.

## Changelog
:cl:
Adjusts meth price.
Adjust weed price
/:cl:
