### PR TITLE
Expands what splats dealer can be

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -568,7 +568,7 @@ SUBSYSTEM_DEF(job)
 
 		to_chat(M, "<b>As the [rank] you answer directly to [job.supervisors]. Special circumstances may change this.</b>")
 		var/mob/living/carbon/human/human = living_mob
-		if((iskindred(human) && human.clane) || iscathayan(human) || isgarou(human))
+		if((iskindred(human) && H.clane) || iscathayan(human) || isgarou(human))
 			if(job.v_duty && job.v_duty != "")
 				to_chat(M, "<span class='notice'><b>[job.v_duty]</b></span>")
 			if(job.title != "Prince")
@@ -741,11 +741,11 @@ SUBSYSTEM_DEF(job)
 
 	if(latejoin_trackers.len)
 		destination = pick(latejoin_trackers)
-		var/mob/living/carbon/human/human = M
+		var/mob/living/carbon/human/H = M
 		if(H.clane)
 			if(H.clane.violating_appearance)
 				destination = pick(GLOB.masquerade_latejoin)
-		if(isgarou(human))
+		if(isgarou(H))
 			for(var/obj/structure/werewolf_totem/W in GLOB.totems)
 				if(W)
 					if(W.tribe == H.auspice.tribe)

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -568,7 +568,7 @@ SUBSYSTEM_DEF(job)
 
 		to_chat(M, "<b>As the [rank] you answer directly to [job.supervisors]. Special circumstances may change this.</b>")
 		var/mob/living/carbon/human/human = living_mob
-		if((iskindred(human) && H.clane) || iscathayan(human) || isgarou(human))
+		if((iskindred(human) && human.clane) || iscathayan(human) || isgarou(human))
 			if(job.v_duty && job.v_duty != "")
 				to_chat(M, "<span class='notice'><b>[job.v_duty]</b></span>")
 			if(job.title != "Prince")

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -567,8 +567,8 @@ SUBSYSTEM_DEF(job)
 				handle_auto_deadmin_roles(M.client, rank)
 
 		to_chat(M, "<b>As the [rank] you answer directly to [job.supervisors]. Special circumstances may change this.</b>")
-		var/mob/living/carbon/human/H = living_mob
-		if((iskindred(H) && H.clane))
+		var/mob/living/carbon/human/human = living_mob
+		if((iskindred(human) && human.clane) || iscathayan(human) || isgarou(human))
 			if(job.v_duty && job.v_duty != "")
 				to_chat(M, "<span class='notice'><b>[job.v_duty]</b></span>")
 			if(job.title != "Prince")
@@ -741,11 +741,11 @@ SUBSYSTEM_DEF(job)
 
 	if(latejoin_trackers.len)
 		destination = pick(latejoin_trackers)
-		var/mob/living/carbon/human/H = M
+		var/mob/living/carbon/human/human = M
 		if(H.clane)
 			if(H.clane.violating_appearance)
 				destination = pick(GLOB.masquerade_latejoin)
-		if(isgarou(H))
+		if(isgarou(human))
 			for(var/obj/structure/werewolf_totem/W in GLOB.totems)
 				if(W)
 					if(W.tribe == H.auspice.tribe)

--- a/code/modules/vtmb/jobs/dealer.dm
+++ b/code/modules/vtmb/jobs/dealer.dm
@@ -27,9 +27,9 @@
 	known_contacts = list("Prince","Seneschal", "Sheriff", "Baron")
 	allowed_bloodlines = list("True Brujah", "Brujah", "Nosferatu", "Gangrel", "Toreador", "Malkavian", "Banu Haqim", "Tzimisce", "Caitiff", "Ventrue", "Ministry", "Kiasyd", "Cappadocian")
 
-	v_duty = "You provide supplies to other kindred. The warehouse is yours, and it's your business who you'll deal with."
+	v_duty = "You provide both legal and illegal supplies to those that get busy during the night. You are your own man yet you know people are out for you. Time to buckle in..."
 	minimal_masquerade = 3
-	allowed_species = list("Vampire")
+	allowed_species = list("Vampire", "Werewolf", "Kuei-Jin")
 	experience_addition = 20
 
 /datum/outfit/job/dealer


### PR DESCRIPTION
## About The Pull Request

After a conversation about a lack of roles for KJ, I gave it some thought and looked at dealer and thought it would be interesting to let Garou be a wise-guy glasswalker and run the warehouse, or let a black spiral try to start a drug ring within the warehouse too.  So this PR effectively makes the warehouse a wild card and its own power through economic might which seems to be the way of things moving into the future.

## Why It's Good For The Game

Round diversity is, mostly, the number one goal here. The fact that the warehouse isnt guaranteed to be Camarilla aligned will allow more inter-round diplomacy and even the allowance of gimmicks on an easier scale, like a glasswalker dealer of the wise-guy camp.

## Changelog

:cl:
Add: Allows werewolves & wk to be a Dealer.
Changes: The job text when you join.
/:cl:

