### PR TITLE
Increases money stack limit by 5x, up to 5000

### DIFF
--- a/code/modules/wod13/cargo.dm
+++ b/code/modules/wod13/cargo.dm
@@ -418,7 +418,7 @@
 	righthand_file = null
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
 	w_class = WEIGHT_CLASS_TINY
-	max_amount = 1000
+	max_amount = 5000
 	merge_type = /obj/item/stack/dollar
 
 /obj/item/stack/dollar/Initialize(mapload, new_amount, merge = TRUE, list/mat_override=null, mat_amt=1)


### PR DESCRIPTION
It's hard to carry so much CASH around, especially for wealthier characters that will need to dedicate 10 slots in their bags if they're carrying 10000 dollars. This PR increases the limit as a form of QoL.