### PR TITLE
Fixes switchblade having inconsistent stats when created

### DIFF
--- a/code/modules/wod13/melee.dm
+++ b/code/modules/wod13/melee.dm
@@ -720,17 +720,21 @@
 	desc = "A spring-loaded knife. Perfect for stabbing sharks and jets."
 	flags_1 = CONDUCT_1
 	force = 5
-	icon_state = "switchblade" //sprite by Spefo
-	w_class = WEIGHT_CLASS_NORMAL
+	icon_state = "switchblade0" //sprite by Spefo
+	w_class = WEIGHT_CLASS_TINY
 	block_chance = 3
 	throwforce = 5
 	throw_speed = 3
 	throw_range = 6
+	armour_penetration = 0
+	grid_width = 1 GRID_BOXES
+	grid_height = 1 GRID_BOXES
+	sharpness = SHARP_NONE
 	hitsound = 'sound/weapons/genhit.ogg'
 	attack_verb_continuous = list("stubs", "pokes")
 	attack_verb_simple = list("stub", "poke")
 	resistance_flags = FIRE_PROOF
-	var/extended = TRUE
+	var/extended = FALSE
 
 /obj/item/melee/vampirearms/knife/switchblade/attack_self(mob/user)
 	extended = !extended


### PR DESCRIPTION
It had some unintended behavior in that regard, this PR fixes it. It now properly spawns sheathed.