### PR TITLE
Protean Walancing: Try One

### DIFF
--- a/code/modules/vtmb/vampire_clane/tzimisce.dm
+++ b/code/modules/vtmb/vampire_clane/tzimisce.dm
@@ -709,8 +709,8 @@
 	mob_size = MOB_SIZE_HUGE
 	speak_chance = 0
 	speed = -0.4
-	maxHealth = 400
-	health = 400
+	maxHealth = 350
+	health = 350
 	butcher_results = list(/obj/item/stack/human_flesh = 10)
 	harm_intent_damage = 5
 	melee_damage_lower = 40
@@ -728,8 +728,8 @@
 	possible_a_intents = list(INTENT_HELP, INTENT_GRAB, INTENT_DISARM, INTENT_HARM)
 
 /mob/living/simple_animal/hostile/gangrel/better
-	maxHealth = 500
-	health = 500
+	maxHealth = 400
+	health = 400
 	melee_damage_lower = 45
 	melee_damage_upper = 45
 	speed = -0.6
@@ -737,8 +737,8 @@
 /mob/living/simple_animal/hostile/gangrel/best
 	icon_state = "gangrel_m"
 	icon_living = "gangrel_m"
-	maxHealth = 600
-	health = 600
+	maxHealth = 500
+	health = 500
 	melee_damage_lower = 55
 	melee_damage_upper = 55
 	speed = -0.8

--- a/code/modules/wod13/melee.dm
+++ b/code/modules/wod13/melee.dm
@@ -391,7 +391,8 @@
 		return
 	if(isliving(target))
 		var/mob/living/L = target
-		L.apply_damage(30, CLONE)
+		L.apply_damage(15, CLONE) //what possessed someone to select 30 agg beforehand?
+		L.apply_damage(15, BRUTE)
 
 /obj/item/melee/vampirearms/knife/gangrel/lasombra
 	name = "shadow tentacle"


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Rebalances Protean,
Protean Claws go from applying **30** Clone Damage on hit, To applying **15** Clone Damage and **15** Brute Damage
Rebalances the Protean Warform Healthpools

## Why It's Good For The Game
Lets talk some numbers here, 

The baseline Garou attack in their Crinos form deals a total of **2** Clone Damage

Meanwhile, the first level of Protean provides users with `/obj/item/melee/vampirearms/knife/gangrel`, a humble weapon dealing a total of 30 points almost unhealable clone damage with **100%** AP.

I don't think any Protean 1 user should be dealing Fifteen times the clone damage done by garou. This PR gives them a far more reasonable number of 15 CL, with 15 much easier to heal brute. If the value is STILL too high, I'll adjust as needed.

As for the health changes, the war-form health really shouldn't be scaling that rapidly.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Rebalances Protean
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
