### PR TITLE
Fixes the screaming emote audio not working

### DIFF
--- a/code/__DEFINES/cooldowns.dm
+++ b/code/__DEFINES/cooldowns.dm
@@ -36,6 +36,9 @@
 #define COOLDOWN_MECHA_MELEE_ATTACK "mecha_melee"
 #define COOLDOWN_MECHA_SMOKE "mecha_smoke"
 
+///Used to check when doing audible emotes, like screaming
+#define COOLDOWN_MOB_AUDIO "mob_audio_cooldown"
+
 //TIMER COOLDOWN MACROS
 
 #define COMSIG_CD_STOP(cd_index) "cooldown_[cd_index]"

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -23,8 +23,9 @@
 	var/stat_allowed = CONSCIOUS
 	var/sound //Sound to play when emote is called
 	var/vary = FALSE	//used for the honk borg emote
-	var/only_forced_audio = FALSE //can only code call this event instead of the player.
 	var/cooldown = 0.8 SECONDS
+	///How often we can do this audio cooldown
+	var/audio_cooldown = 10 SECONDS
 
 /datum/emote/New()
 	if (ispath(mob_type_allowed_typecache))
@@ -50,28 +51,18 @@
 
 	msg = replace_pronoun(user, msg)
 
-	if(isliving(user))
-		var/mob/living/L = user
-		for(var/obj/item/implant/I in L.implants)
-			I.trigger(key, L)
-
 	if(!msg)
 		return
 
 	user.log_message(msg, LOG_EMOTE)
-	// var/dchatmsg = "<b>[user]</b> [msg]"
 
 	var/tmp_sound = get_sound(user)
-	if(tmp_sound && (!only_forced_audio || !intentional))
+	if(tmp_sound)
+		if(TIMER_COOLDOWN_CHECK(user, COOLDOWN_MOB_AUDIO))
+			return
+		TIMER_COOLDOWN_START(user, type, audio_cooldown)
+		S_TIMER_COOLDOWN_START(user, COOLDOWN_MOB_AUDIO, 10 SECONDS)
 		playsound(user, tmp_sound, 50, vary)
-	/* // [ChillRaccoon] - ghosts shouldn't see emotes if they arent see emoting object
-	for(var/mob/M in GLOB.dead_mob_list)
-		if(!M.client || isnewplayer(M))
-			continue
-		var/T = get_turf(user)
-		if(M.stat == DEAD && M.client && user.client && (M.client.prefs.chat_toggles & CHAT_GHOSTSIGHT) && !(M in viewers(T, null)))
-			M.show_message("[FOLLOW_LINK(M, user)] [dchatmsg]")
-	*/
 
 	if(emote_type == EMOTE_AUDIBLE)
 		user.audible_message(msg, audible_message_flags = EMOTE_MESSAGE)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -50,7 +50,6 @@
 	message = "screams!"
 	message_mime = "acts out a scream!"
 	emote_type = EMOTE_AUDIBLE
-	only_forced_audio = TRUE
 	vary = TRUE
 
 /datum/emote/living/carbon/human/scream/get_sound(mob/living/user)
@@ -59,16 +58,14 @@
 	var/mob/living/carbon/human/H = user
 	if(H.mind?.miming)
 		return
-	if(ishumanbasic(H) || isfelinid(H))
+	if(ishuman(H))
 		if(user.gender == FEMALE)
 			return pick('sound/voice/human/femalescream_1.ogg', 'sound/voice/human/femalescream_2.ogg', 'sound/voice/human/femalescream_3.ogg', 'sound/voice/human/femalescream_4.ogg', 'sound/voice/human/femalescream_5.ogg')
 		else
 			if(prob(1))
 				return 'sound/voice/human/wilhelm_scream.ogg'
 			return pick('sound/voice/human/malescream_1.ogg', 'sound/voice/human/malescream_2.ogg', 'sound/voice/human/malescream_3.ogg', 'sound/voice/human/malescream_4.ogg', 'sound/voice/human/malescream_5.ogg', 'sound/voice/human/malescream_6.ogg')
-	else if(ismoth(H))
-		return 'sound/voice/moth/scream_moth.ogg'
-	else if(ismonkey(user)) //If its a monkey, override it.
+	else if(ismonkey(user))
 		return pick('sound/creatures/monkey/monkey_screech_1.ogg',
 					'sound/creatures/monkey/monkey_screech_2.ogg',
 					'sound/creatures/monkey/monkey_screech_3.ogg',


### PR DESCRIPTION
## About The Pull Request

No matter the source, the audio check for emotes always failed. This PR (attempts to) fix audible emotes (currently, scream only).

I added a default 10 seconds cooldown between audible emotes and a variable for the scream emote itself. These can be tweaked later when we add other audible emotes (like werewolf growling, etc) and a potential delay bypass. I stepped over it with the debugger many times, but it might still not be perfect, say code is daunting.

Tested it by:
- Spawning in as female garou, *scream
- Spawning in as vampire, set gender to male, *scream
- Punching NPCs to hear them scream

https://github.com/user-attachments/assets/600186b9-691d-41b3-a5af-f25af2df0e16
 
## Why It's Good For The Game

Bug bad, fixes this report:

![image](https://github.com/user-attachments/assets/7babe91f-6bfa-44be-8baa-09555ebd1853)

## Changelog

:cl:
fix: The scream emote is audible now, both by players and NPCs.
/:cl:
