### PR TITLE
Gets rid of lengthy if-else chain in parse_zone() proc

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -549,24 +549,25 @@ Turf and target are separate in case you want to teleport some distance from a t
 	return (rand(1,value)==value)
 
 /proc/parse_zone(zone)
-	if(zone == BODY_ZONE_PRECISE_R_HAND)
-		return "right hand"
-	else if (zone == BODY_ZONE_PRECISE_L_HAND)
-		return "left hand"
-	else if (zone == BODY_ZONE_L_ARM)
-		return "left arm"
-	else if (zone == BODY_ZONE_R_ARM)
-		return "right arm"
-	else if (zone == BODY_ZONE_L_LEG)
-		return "left leg"
-	else if (zone == BODY_ZONE_R_LEG)
-		return "right leg"
-	else if (zone == BODY_ZONE_PRECISE_L_FOOT)
-		return "left foot"
-	else if (zone == BODY_ZONE_PRECISE_R_FOOT)
-		return "right foot"
-	else
-		return zone
+	switch(zone)
+		if(BODY_ZONE_PRECISE_R_HAND)
+			return "right hand"
+		if (BODY_ZONE_PRECISE_L_HAND)
+			return "left hand"
+		if (BODY_ZONE_L_ARM)
+			return "left arm"
+		if (BODY_ZONE_R_ARM)
+			return "right arm"
+		if (BODY_ZONE_L_LEG)
+			return "left leg"
+		if (BODY_ZONE_R_LEG)
+			return "right leg"
+		if (BODY_ZONE_PRECISE_L_FOOT)
+			return "left foot"
+		if (BODY_ZONE_PRECISE_R_FOOT)
+			return "right foot"
+		else
+			return zone
 
 /*
 


### PR DESCRIPTION
## About The Pull Request
Turns a lengthy if-else chain in /proc/parse_zone into a switch, this proc is usually used to get the name for body parts, specifically to translate the define names of them to more common words for them.
![firefox_2025-01-25_16-48-22](https://github.com/user-attachments/assets/74143e41-8932-45f3-aa94-96203cf7eb18)

(Reference for what the defines are and why things like head & mouth & torso are not included since they get spat out at the else end)
![Code_2025-01-25_15-51-10](https://github.com/user-attachments/assets/d599ecf9-f27d-4eb3-992b-b99f79d170e6)

Image of it working in game (as you can see the body parts are named right leg and left leg and so on instead of r_leg and l_leg)
![dreamseeker_2025-01-25_16-35-01](https://github.com/user-attachments/assets/1933ff9f-bcf2-4d2a-8083-44bf0d1dc2db)

Runtime present in screenshot is from master itself and unrelated to this PR.
## Why It's Good For The Game
Efficient code! That is good and looks pleasant! Yes!!

## Changelog

Not needed, purely code efficiency related.
