### PR TITLE
Fixes roundstart runtime issue.

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -376,7 +376,7 @@
 	display_name = "Arcade Games"
 	description = "For the slackers on the station."
 	prereq_ids = list("comptech")
-	design_ids = list("arcade_battle", "arcade_orion", "slotmachine")
+	design_ids = list("arcade_battle", "arcade_orion")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
 
 /datum/techweb_node/comp_recordkeeping


### PR DESCRIPTION
## About The Pull Request
On research subsystem firing/initializing it would go through design_ids to see if there were any invalid or null ones, this one was throwing a runtime on master because #595 accidentally left it in which caused a runtime on running the server.

![bild](https://github.com/user-attachments/assets/f288a8d7-eaf8-4322-acac-1f8f832394a3)
![dreamseeker_2025-01-25_17-01-49](https://github.com/user-attachments/assets/a2e60826-ecf3-45ec-877d-c5f5c407fe8c)

## Why It's Good For The Game
Runtimes? BAD!

## Changelog
Less runtimes, less problems, more development.
