### PR TITLE
Adds ventrue keys to ventrue characters

### DIFF
--- a/code/modules/vtmb/vampire_clane/ventrue.dm
+++ b/code/modules/vtmb/vampire_clane/ventrue.dm
@@ -9,6 +9,7 @@
 	)
 	male_clothes = /obj/item/clothing/under/vampire/ventrue
 	female_clothes = /obj/item/clothing/under/vampire/ventrue/female
+	clan_keys = /obj/item/vamp/keys/ventrue
 
 /datum/discipline/dominate/post_gain(mob/living/carbon/human/H)
 	if(level >= 1)


### PR DESCRIPTION
## About The Pull Request

The Ventrue don't spawn with their keys, this fixes (??) it. Unless it was intended that only the Primogen can open doors for their entire clan (in that case, please close this).

Spawned in as a Ventrue Prince (got Prince keys + Ventrue keys), then spawned in as a Ventrue Citizen:

![image](https://github.com/user-attachments/assets/05fed983-9255-417c-aaf7-8ed33a38026b)

## Why It's Good For The Game

The Ventrue have their own haven, but they cannot access it without the Ventrue Primogen being a doorman for them.

## Changelog

:cl:
fix: The Ventrue now spawn with their clan keys.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
