### PR TITLE
Changes sniper rifle caliber to .50, massively increases damage

### DIFF
--- a/code/modules/wod13/guns.dm
+++ b/code/modules/wod13/guns.dm
@@ -491,8 +491,8 @@
 /obj/item/ammo_box/magazine/internal/vampire/sniper
 	name = "sniper rifle internal magazine"
 	desc = "Oh god, this shouldn't be here"
-	ammo_type = /obj/item/ammo_casing/vampire/c556mm
-	caliber = CALIBER_556
+	ammo_type = /obj/item/ammo_casing/vampire/c50
+	caliber = CALIBER_50
 	max_ammo = 5
 	multiload = TRUE
 
@@ -522,7 +522,7 @@
 	zoom_amt = 10 //Long range, enough to see in front of you, but no tiles behind you.
 	zoom_out_amt = 5
 	slot_flags = ITEM_SLOT_BACK
-	projectile_damage_multiplier = 1.5
+	projectile_damage_multiplier = 2 //140 damage. Nice.
 	actions_types = list()
 	masquerade_violating = TRUE
 	cost = 250


### PR DESCRIPTION
It's not exactly a new unique caliber but that's because I thought I'd have to add this caliber to the game.
Changed the sniper rifle's ammo to .50 bullets, which are kinda meant to be used with sniper rifles anyway.
Changed the damage multiplier from 1.5 to 2.
In total this makes the sniper rifle go from 67.5 damage to 140 damage. Welcome back crossbows (keep in mind they have a 4 second fire delay between shots without Gunslinger, while Crossbows could fire immediately after).

To-do: Replace the associated 5.56 ammo boxes with .50 ammo boxes wherever a sniper rifle appears.
To-do: Actually test this.