### PR TITLE
Reduces drug lab cost by 60%

### DIFF
--- a/code/modules/wod13/cargo.dm
+++ b/code/modules/wod13/cargo.dm
@@ -21,7 +21,7 @@
 /datum/supply_pack/vampire/methlab
 	name = "Lab Equipment"
 	desc = "Contains lab equipment."
-	cost = 10000
+	cost = 2000
 	contains = list(/obj/structure/methlab/movable)
 
 /datum/supply_pack/vampire/gas_can

--- a/code/modules/wod13/cargo.dm
+++ b/code/modules/wod13/cargo.dm
@@ -21,7 +21,7 @@
 /datum/supply_pack/vampire/methlab
 	name = "Lab Equipment"
 	desc = "Contains lab equipment."
-	cost = 2000
+	cost = 4000
 	contains = list(/obj/structure/methlab/movable)
 
 /datum/supply_pack/vampire/gas_can


### PR DESCRIPTION
## About The Pull Request
Reduced the drug lab's cost from $10000 to $4000.

## Why It's Good For The Game
The drug lab is extremely expensive and takes way too much luck to make up for its cost compared to something like selling green packages. It also locks anyone who doesn't have at least Social 5 in it away from making any sort of long-term profit. Very unprofitable, mainly due to its steep initial cost, which this PR reduces.
## Changelog

:cl:
balance: The drug lab's price is now $4000 instead of $10000.
/:cl: