### PR TITLE
Fixes rat-caused runtime which means you can store and throw them from your hand again & Animalism 5 fix.

### DIFF
--- a/code/modules/wod13/npcroles.dm
+++ b/code/modules/wod13/npcroles.dm
@@ -824,8 +824,10 @@
 
 /mob/living/simple_animal/pet/rat/Life()
 	. = ..()
+	if(!isturf(loc)) // if rat is, for example, in-hand or inside a crate, won't run this self-deletion code
+		return
 	var/delete_me = TRUE
-	for(var/mob/living/carbon/human/H in oviewers(5, src))
+	for(var/mob/living/carbon/human/H in viewers(5, src))
 		if(H)
 			delete_me = FALSE
 	if(delete_me)

--- a/code/modules/wod13/npcroles.dm
+++ b/code/modules/wod13/npcroles.dm
@@ -834,7 +834,7 @@
 		death()
 
 /mob/living/simple_animal/pet/rat/will_escape_storage()
-	if(prob(25))
+	if(prob(10))
 		return TRUE
 	else
 		return FALSE

--- a/code/modules/wod13/npcroles.dm
+++ b/code/modules/wod13/npcroles.dm
@@ -826,6 +826,8 @@
 	. = ..()
 	if(!isturf(loc)) // if rat is, for example, in-hand or inside a crate, won't run this self-deletion code
 		return
+	if(src.client)
+		return
 	var/delete_me = TRUE
 	for(var/mob/living/carbon/human/H in viewers(5, src))
 		if(H)

--- a/code/modules/wod13/npcroles.dm
+++ b/code/modules/wod13/npcroles.dm
@@ -836,8 +836,7 @@
 /mob/living/simple_animal/pet/rat/will_escape_storage()
 	if(prob(10))
 		return TRUE
-	else
-		return FALSE
+	return FALSE
 
 /mob/living/simple_animal/hostile/beastmaster/rat
 	name = "rat"

--- a/code/modules/wod13/npcroles.dm
+++ b/code/modules/wod13/npcroles.dm
@@ -833,6 +833,12 @@
 	if(delete_me)
 		death()
 
+/mob/living/simple_animal/pet/rat/will_escape_storage()
+	if(prob(25))
+		return TRUE
+	else
+		return FALSE
+
 /mob/living/simple_animal/hostile/beastmaster/rat
 	name = "rat"
 	desc = "It's a rat."

--- a/code/modules/wod13/npcroles.dm
+++ b/code/modules/wod13/npcroles.dm
@@ -826,7 +826,7 @@
 	. = ..()
 	if(!isturf(loc)) // if rat is, for example, in-hand or inside a crate, won't run this self-deletion code
 		return
-	if(src.client)
+	if(client)
 		return
 	var/delete_me = TRUE
 	for(var/mob/living/carbon/human/H in viewers(5, src))


### PR DESCRIPTION
## About The Pull Request
When a rat is not "in view" of anything it deletes itself to not cause mass-rat-event.
If you pick a rat up, it is not "in view" and deletes itself, but the mob-holder code will still have it in your hand or in your bag until you decide to drop it in which case it runtimes, because forcemove is given a null destination, and then deletes the rat.
This adds a check so that, if the rat is technically not anywhere, the rat won't be deleted inside things like crates or backpacks.
Also changes oviewers to viewers so that it won't try to delete itself if its viewed by the person holding it.
Added a check for if the rat is controlled by a client (like with current animalism 5) in which case we don't want to delete it suddenly.

Credits for the help needed to identify, diagnose, and patch this issue with the people in the discord: silencer_pl, adri, and steve5315
## Why It's Good For The Game
Being able to store a mass quantity of rats in your backpack and being able to throw them at people is a hallowed tradition for nosferatu and it is truly a shame that the current state of things disallows such practice. Also runtimes are icky.

## Changelog
:cl: Vondiech/Citruses
fix: You can now pick up, store in bag, and throw rats again without them disappearing.
fix: Animalism 5 rat-shapeshifting no longer gets immediately undone when out of view.
/:cl:
