### PR TITLE
Mytherceria disorient runtime fixes

### DIFF
--- a/code/modules/vtmb/vampire_clane/kiasyd.dm
+++ b/code/modules/vtmb/vampire_clane/kiasyd.dm
@@ -354,14 +354,14 @@
 	unique = TRUE
 	icon_state = "rune2"
 
-/obj/mytherceria_trap/disorient/Crossed(atom/movable/AM)
+/obj/mytherceria_trap/disorient/Crossed(atom/movable/target)
 	..()
-	if(isliving(AM) && owner)
-		var/mob/living/L = AM
-		if(!L.client)
+	if(isliving(target) && owner)
+		var/mob/living/livingtarget = target
+		if(!livingtarget.client)
 			return
-		else if(AM != owner)
-			var/list/screens = list(L.hud_used.plane_masters["[FLOOR_PLANE]"], L.hud_used.plane_masters["[GAME_PLANE]"], L.hud_used.plane_masters["[LIGHTING_PLANE]"])
+		else if(target != owner)
+			var/list/screens = list(livingtarget.hud_used.plane_masters["[FLOOR_PLANE]"], livingtarget.hud_used.plane_masters["[GAME_PLANE]"], livingtarget.hud_used.plane_masters["[LIGHTING_PLANE]"])
 			var/rotation = 50
 			for(var/whole_screen in screens)
 				animate(whole_screen, transform = matrix(rotation, MATRIX_ROTATE), time = 0.5 SECONDS, easing = QUAD_EASING, loop = -1)

--- a/code/modules/vtmb/vampire_clane/kiasyd.dm
+++ b/code/modules/vtmb/vampire_clane/kiasyd.dm
@@ -167,6 +167,9 @@
 			var/obj/item/clothing/mask/facehugger/kiasyd/K = new (get_turf(caster))
 			K.throw_at(target, 10, 14, caster)
 		if(4)
+			if(!target.client)
+				to_chat(caster,"<span class='danger'>This one has no brains!</span>")
+				return
 			var/list/screens = list(target.hud_used.plane_masters["[FLOOR_PLANE]"], target.hud_used.plane_masters["[GAME_PLANE]"], target.hud_used.plane_masters["[LIGHTING_PLANE]"])
 			var/rotation = 50
 			for(var/whole_screen in screens)
@@ -356,6 +359,8 @@
 	if(isliving(AM) && owner)
 		if(AM != owner)
 			var/mob/living/L = AM
+			if(!L.client)
+				return
 			var/list/screens = list(L.hud_used.plane_masters["[FLOOR_PLANE]"], L.hud_used.plane_masters["[GAME_PLANE]"], L.hud_used.plane_masters["[LIGHTING_PLANE]"])
 			var/rotation = 50
 			for(var/whole_screen in screens)

--- a/code/modules/vtmb/vampire_clane/kiasyd.dm
+++ b/code/modules/vtmb/vampire_clane/kiasyd.dm
@@ -357,11 +357,11 @@
 /obj/mytherceria_trap/disorient/Crossed(atom/movable/target)
 	..()
 	if(isliving(target) && owner)
-		var/mob/living/livingtarget = target
-		if(!livingtarget.client)
+		var/mob/living/living_target = target
+		if(!living_target.client)
 			return
 		else if(target != owner)
-			var/list/screens = list(livingtarget.hud_used.plane_masters["[FLOOR_PLANE]"], livingtarget.hud_used.plane_masters["[GAME_PLANE]"], livingtarget.hud_used.plane_masters["[LIGHTING_PLANE]"])
+			var/list/screens = list(living_target.hud_used.plane_masters["[FLOOR_PLANE]"], living_target.hud_used.plane_masters["[GAME_PLANE]"], living_target.hud_used.plane_masters["[LIGHTING_PLANE]"])
 			var/rotation = 50
 			for(var/whole_screen in screens)
 				animate(whole_screen, transform = matrix(rotation, MATRIX_ROTATE), time = 0.5 SECONDS, easing = QUAD_EASING, loop = -1)

--- a/code/modules/vtmb/vampire_clane/kiasyd.dm
+++ b/code/modules/vtmb/vampire_clane/kiasyd.dm
@@ -357,10 +357,10 @@
 /obj/mytherceria_trap/disorient/Crossed(atom/movable/AM)
 	..()
 	if(isliving(AM) && owner)
-		if(AM != owner)
-			var/mob/living/L = AM
-			if(!L.client)
-				return
+		var/mob/living/L = AM
+		if(!L.client)
+			return
+		else if(AM != owner)
 			var/list/screens = list(L.hud_used.plane_masters["[FLOOR_PLANE]"], L.hud_used.plane_masters["[GAME_PLANE]"], L.hud_used.plane_masters["[LIGHTING_PLANE]"])
 			var/rotation = 50
 			for(var/whole_screen in screens)


### PR DESCRIPTION
## About The Pull Request
These two abilities are supposed to disorient another persons hud, either from casting myth 4 on them or from being caught in a spin trap, however if they don't have a client, like NPCs or simple_mobs, they don't have a hud and this then throws a runtime when they are caught in these. Adds checks for both to make sure that the code only triggers when someone with a client (and therefor, a hud) is targetted.

![bild](https://github.com/user-attachments/assets/f23f088d-03e0-49ae-bbbf-424fd7751b29)
## Why It's Good For The Game
Runtimes are stinky and complicate things

## Changelog

Yet another runtime cleanup, nothing of note for players to know or care about.