### PR TITLE
Improves Admin Global Narrate

### DIFF
--- a/code/__DEFINES/chat.dm
+++ b/code/__DEFINES/chat.dm
@@ -18,3 +18,7 @@
 #define MESSAGE_TYPE_ADMINLOG "adminlog"
 #define MESSAGE_TYPE_ATTACKLOG "attacklog"
 #define MESSAGE_TYPE_DEBUG "debug"
+
+// Global Narrate
+#define narrate_head(str) ("<div class='narrate_head'><p>" + str + "</p></div>")
+#define narrate_body(str) ("<div class='narrate_body'><p>" + str + "</p></div>")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -134,14 +134,28 @@
 	if(!check_rights(R_ADMIN))
 		return
 
-	var/msg = input("Message:", text("Enter the text you wish to appear to everyone:")) as text|null
+	var/message_header
+	var/message_body
 
-	if (!msg)
-		return
-	to_chat(world, "[msg]", confidential = TRUE)
-	log_admin("GlobalNarrate: [key_name(usr)] : [msg]")
-	message_admins("<span class='adminnotice'>[key_name_admin(usr)] Sent a global narrate</span>")
-	SSblackbox.record_feedback("tally", "admin_verb", 1, "Global Narrate") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	if(tgui_alert(usr, "Do you wish to include a header? Headers use a separate paragraph and a bigger font.", "Narrate: Header", list("Yes","No"), timeout = 0) == "Yes")
+		message_header = input(usr, "Enter HEADER message. You can use the string '</p><p>' to write multiple paragraphs. HTML formating should be respected. Writing nothing or cancelling will still let you send a normal message without a header.","Narrate Header")
+
+	message_body = input(usr, "Enter message. You can use the string '</p><p>' to write multiple paragraphs. HTML formating should be respected. Writing nothing or cancelling will cancel the command.","Narrate Header")
+
+	if(!message_body) return
+
+	if(message_header) to_chat(usr, narrate_head(message_header))
+	to_chat(usr, narrate_body(message_body))
+
+	if(tgui_alert(usr, "Please check your chat window for the finished message. Are you SURE you want to send this message?", "Message Confirmation", list("Yes","No"), timeout = 0) == "Yes")
+
+		if(message_header)
+			to_chat(world, narrate_head(message_header))
+			log_admin("GlobalNarrate: [key_name(usr)] : HEADER - [message_header]]")
+		to_chat(world, narrate_body(message_body))
+		log_admin("GlobalNarrate: [key_name(usr)] : BODY - [message_body]")
+		message_admins("<span class='adminnotice'>[key_name_admin(usr)] Sent a global narrate</span>")
+		SSblackbox.record_feedback("tally", "admin_verb", 1, "Global Narrate") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_direct_narrate(mob/M)
 	set category = "Admin.Events"

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -137,17 +137,17 @@
 	var/message_header
 	var/message_body
 
-	if(tgui_alert(usr, "Do you wish to include a header? Headers use a separate paragraph and a bigger font.", "Narrate: Header", list("Yes","No"), timeout = 0) == "Yes")
-		message_header = input(usr, "Enter HEADER message. You can use the string '</p><p>' to write multiple paragraphs. HTML formating should be respected. Writing nothing or cancelling will still let you send a normal message without a header.","Narrate Header")
+	if(tgui_alert(usr, "Do you wish to include a header? Headers use a separate paragraph and a bigger font.", "Narrate Header", list("Yes","No"), timeout = 0) == "Yes")
+		message_header = input(usr, "Enter HEADER message. HTML tags like <b></b> to bold etc. will be respected. Writing nothing or cancelling will still let you send a normal message without a header.","Narrate Header")
 
-	message_body = input(usr, "Enter message. You can use the string '</p><p>' to write multiple paragraphs. HTML formating should be respected. Writing nothing or cancelling will cancel the command.","Narrate Header")
+	message_body = input(usr, "Enter message. You can use the string '</p><p>' to write multiple paragraphs. HTML tags like <b></b> to bold etc. will be respected. Writing nothing or cancelling will cancel the command.","Narrate Body")
 
 	if(!message_body) return
 
 	if(message_header) to_chat(usr, narrate_head(message_header))
 	to_chat(usr, narrate_body(message_body))
 
-	if(tgui_alert(usr, "Please check your chat window for the finished message. Are you SURE you want to send this message?", "Message Confirmation", list("Yes","No"), timeout = 0) == "Yes")
+	if(tgui_alert(usr, "Please check your chat window for the finished message. Are you SURE you want to send this message?", "Narrate Confirmation", list("Yes","No"), timeout = 0) == "Yes")
 
 		if(message_header)
 			to_chat(world, narrate_head(message_header))

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -167,4 +167,8 @@ h1.alert, h2.alert		{color: #000000;}
 
 .monkeyhive				{color: #774704;}
 .monkeylead				{color: #774704;	font-size: 2;}
+
+.narrate_head {font-size: 3; text-align: center; color: #ffffff;padding: 0em 1em;}
+.narrate_body {font-size: 2; text-align: justify; color: #ffffff;padding: 0em 1em;}
+
 </style>"}

--- a/tgui/packages/tgui-panel/chat/constants.js
+++ b/tgui/packages/tgui-panel/chat/constants.js
@@ -64,7 +64,7 @@ export const MESSAGE_TYPES = [
     type: MESSAGE_TYPE_INFO,
     name: 'Info',
     description: 'Non-urgent messages from the game and items',
-    selector: '.notice:not(.pm), .adminnotice, .info, .sinister, .cult, .infoplain',
+    selector: '.notice:not(.pm), .adminnotice, .info, .sinister, .cult, .infoplain, .narrate_head, .narrate_body',
   },
   {
     type: MESSAGE_TYPE_WARNING,

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -889,3 +889,16 @@ em {
 .ml-3 {
   margin-left: 3em;
 }
+
+//narration
+.narrate_head {
+  font-size: 125%;
+  text-align: center;
+  padding: 0em 1em;
+}
+
+.narrate_body {
+  font-size: 100%;
+  text-align: justify;
+  padding: 0em 1em;
+}

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -930,3 +930,16 @@ h1.alert, h2.alert {
 .ml-3 {
   margin-left: 3em;
 }
+
+//narration
+.narrate_head {
+  font-size: 125%;
+  text-align: center;
+  padding: 0em 1em;
+}
+
+.narrate_body {
+  font-size: 100%;
+  text-align: justify;
+  padding: 0em 1em;
+}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR changes the admin "Global Narrate" command in the following ways:

- The command now asks if the user wishes to use a header, then asks them to enter the header (if selected) and body of the message.
- The command instructs the user about HTML tags and paragraphs where relevant
- The command prints out a test display of the resulting message and asks the user for final verification.
- The command broadcasts the entered sequence to the world.

<details><summary>Click for Example</summary>
<p>

![image](https://github.com/user-attachments/assets/962961f3-8a6c-4806-944f-d019661ae206)


</p>
</details>

Two potential tweaks:

- Removal of the narration question dialog and leaving that just to the header_input box. This however seems very sloppy, to me at least.
- Removal of the preview option. Though maybe I can pull that into a client toggle later if needed.

Both of these likely can be made as admin setting toggles or something, but that's going a tad out of scope than I intended, it is an option though.

## Why It's Good For The Game

There was an admin roleplaying as a DJ and using the in game music player to play songs yesterday and I felt like their messages could very much get lost if someone was not already paying attention. This adds some punch up to the text and generally makes it more readable (walls of text tend to look better justified, which is why the body is that) and also lets admins add an additional, mood setting header which is optional. 

Better mood/narration controls means better admin narrations, means better RP means happier players ;P

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

- Made admin narration more pronounced and offer an optional header.