### PR TITLE
Properly removes Diablerist quirk

### DIFF
--- a/code/modules/wod13/quirks.dm
+++ b/code/modules/wod13/quirks.dm
@@ -645,13 +645,6 @@ Dancer
 		return
 	if(isturf(quirk_holder.loc))
 		SSbloodhunt.announce_hunted(quirk_holder, "Camarilla Wanted List")
-/*
-/datum/quirk/diablerist
-	name = "Black Secret"
-	desc = "You have a small, ancient secret, somehow related to Diablerie, and this decreases your chance to survive another one. <b>This isn't a licence to diablerie anyone you want!</b>"
-	value = -3
-	allowed_species = list("Vampire")
-*/
 
 /datum/quirk/badvision
 	name = "Nearsighted"

--- a/code/modules/wod13/quirks.dm
+++ b/code/modules/wod13/quirks.dm
@@ -651,6 +651,7 @@ Dancer
 	desc = "You have a small, ancient secret, somehow related to Diablerie, and this decreases your chance to survive another one. <b>This isn't a licence to diablerie anyone you want!</b>"
 	value = -3
 	allowed_species = list("Vampire")
+*/
 
 /datum/quirk/badvision
 	name = "Nearsighted"

--- a/code/modules/wod13/quirks.dm
+++ b/code/modules/wod13/quirks.dm
@@ -651,12 +651,13 @@ Dancer
 	desc = "You have a small, ancient secret, somehow related to Diablerie, and this decreases your chance to survive another one. <b>This isn't a licence to diablerie anyone you want!</b>"
 	value = -3
 	allowed_species = list("Vampire")
-*/
+
 /datum/quirk/diablerist/on_spawn()
 	if(iswerewolf(quirk_holder) || isgarou(quirk_holder))
 		return
 	var/mob/living/carbon/human/H = quirk_holder
 	H.diablerist = TRUE
+*/
 
 /datum/quirk/badvision
 	name = "Nearsighted"

--- a/code/modules/wod13/quirks.dm
+++ b/code/modules/wod13/quirks.dm
@@ -652,13 +652,6 @@ Dancer
 	value = -3
 	allowed_species = list("Vampire")
 
-/datum/quirk/diablerist/on_spawn()
-	if(iswerewolf(quirk_holder) || isgarou(quirk_holder))
-		return
-	var/mob/living/carbon/human/H = quirk_holder
-	H.diablerist = TRUE
-*/
-
 /datum/quirk/badvision
 	name = "Nearsighted"
 	desc = "Your eye illness somehow did not become cured after the Embrace, and you need to wear perception glasses."


### PR DESCRIPTION
## About The Pull Request
Properly removes the Diablerist quirk from the game, which showed up as "Test Quirk" in the quirk menu.
It did not have any permanent consequences, it merely marked the character as a diablerist for the duration of a round.

## Why It's Good For The Game
It's a bugfix. It was intended to be deleted months ago.

## Changelog
:cl:
fix: Properly removed the Diablerist quirk from the game.
/:cl: