### PR TITLE
Cruelty will now respect gun damage multipliers

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -576,7 +576,7 @@
 			var/mob/living/carbon/human/frer = firer
 			if(frer.blood)
 				if(prob(frer.get_total_blood()*10))
-					damage = initial(damage)*2
+					damage *= 2
 	if(temporary_unstoppable_movement)
 		temporary_unstoppable_movement = FALSE
 		movement_type &= ~PHASING


### PR DESCRIPTION
Turns out it would reset the damage back to the initial value multiplied by 2, which messes with 3 different guns that have damage multipliers (snub-nosed revolvers, sniper rifles and the semi-auto shotguns). This fixes it.