### PR TITLE
Gunfighter now only reduces delay by half instead of removing it

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -270,6 +270,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_CHARMER			"charmer"
 #define TRAIT_UNMASQUERADE		"unmasquerade"	//For tzi clothing
 #define TRAIT_NONMASQUERADE		"nonmasquerade"	//For tzi mods
+#define TRAIT_GUNFIGHTER        "gunfighter"    //Halves firing delay and cooldown between burst fire shots
 /// Makes gambling incredibly effective, and causes random beneficial events to happen for the mob.
 #define TRAIT_SUPERNATURAL_LUCK	"supernatural_luck"
 /// Lets the mob block projectiles like bullets using only their hands.

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -125,6 +125,8 @@
 
 	var/can_be_embraced = TRUE
 
+	var/halved_fire_delay = FALSE
+
 	yang_chi = 4
 	max_yang_chi = 4
 	yin_chi = 2

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -125,8 +125,6 @@
 
 	var/can_be_embraced = TRUE
 
-	var/halved_fire_delay = FALSE
-
 	yang_chi = 4
 	max_yang_chi = 4
 	yin_chi = 2

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -202,7 +202,7 @@
 	var/last_taste_time
 	var/last_taste_text
 
-	var/no_fire_delay = FALSE
+	var/halved_fire_delay = FALSE
 
 	var/experience_plus = 0
 	var/discipline_time_plus = 0

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -202,8 +202,6 @@
 	var/last_taste_time
 	var/last_taste_text
 
-	var/halved_fire_delay = FALSE
-
 	var/experience_plus = 0
 	var/discipline_time_plus = 0
 	var/bloodpower_time_plus = 0

--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -16,14 +16,13 @@
 		AddComponent(/datum/component/pellet_cloud, projectile_type, pellets)
 		SEND_SIGNAL(src, COMSIG_PELLET_CLOUD_INIT, target, user, fired_from, randomspread, spread, zone_override, params, distro)
 
-	var/mob/living/carbon/human/shooter = user
 	if(click_cooldown_override)
-		if((click_cooldown_override > CLICK_CD_RAPID) && HAS_TRAIT(shooter, TRAIT_GUNFIGHTER))
+		if((click_cooldown_override > CLICK_CD_RAPID) && HAS_TRAIT(user, TRAIT_GUNFIGHTER))
 			user.changeNext_move(max(CLICK_CD_RAPID, round(click_cooldown_override/2)))
 		else
 			user.changeNext_move(click_cooldown_override)
 	else
-		if(HAS_TRAIT(shooter, TRAIT_GUNFIGHTER))
+		if(HAS_TRAIT(user, TRAIT_GUNFIGHTER))
 			user.changeNext_move(CLICK_CD_RAPID)
 		else
 			user.changeNext_move(CLICK_CD_RANGE)

--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -17,14 +17,13 @@
 		SEND_SIGNAL(src, COMSIG_PELLET_CLOUD_INIT, target, user, fired_from, randomspread, spread, zone_override, params, distro)
 
 	var/mob/living/carbon/human/shooter = user
-	var/less_firing_delay = shooter.halved_fire_delay
 	if(click_cooldown_override)
-		if((click_cooldown_override > CLICK_CD_RAPID) && less_firing_delay)
+		if((click_cooldown_override > CLICK_CD_RAPID) && HAS_TRAIT(shooter, TRAIT_GUNFIGHTER))
 			user.changeNext_move(max(CLICK_CD_RAPID, round(click_cooldown_override/2)))
 		else
 			user.changeNext_move(click_cooldown_override)
 	else
-		if(less_firing_delay)
+		if(HAS_TRAIT(shooter, TRAIT_GUNFIGHTER))
 			user.changeNext_move(CLICK_CD_RAPID)
 		else
 			user.changeNext_move(CLICK_CD_RANGE)

--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -18,14 +18,14 @@
 
 	if(click_cooldown_override)
 		if(click_cooldown_override > CLICK_CD_RAPID)
-			if(user.no_fire_delay)
+			if(user.halved_fire_delay)
 				user.changeNext_move(max(CLICK_CD_RAPID, round(click_cooldown_override/2)))
 			else
 				user.changeNext_move(click_cooldown_override)
 		else
 			user.changeNext_move(click_cooldown_override)
 	else
-		if(user.no_fire_delay)
+		if(user.halved_fire_delay)
 			user.changeNext_move(CLICK_CD_RAPID)
 		else
 			user.changeNext_move(CLICK_CD_RANGE)

--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -16,16 +16,15 @@
 		AddComponent(/datum/component/pellet_cloud, projectile_type, pellets)
 		SEND_SIGNAL(src, COMSIG_PELLET_CLOUD_INIT, target, user, fired_from, randomspread, spread, zone_override, params, distro)
 
+	var/mob/living/carbon/human/shooter = user
+	var/less_firing_delay = shooter.halved_fire_delay
 	if(click_cooldown_override)
-		if(click_cooldown_override > CLICK_CD_RAPID)
-			if(user.halved_fire_delay)
-				user.changeNext_move(max(CLICK_CD_RAPID, round(click_cooldown_override/2)))
-			else
-				user.changeNext_move(click_cooldown_override)
+		if((click_cooldown_override > CLICK_CD_RAPID) && less_firing_delay)
+			user.changeNext_move(max(CLICK_CD_RAPID, round(click_cooldown_override/2)))
 		else
 			user.changeNext_move(click_cooldown_override)
 	else
-		if(user.halved_fire_delay)
+		if(less_firing_delay)
 			user.changeNext_move(CLICK_CD_RAPID)
 		else
 			user.changeNext_move(CLICK_CD_RANGE)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -328,7 +328,7 @@
 	if(burst_size > 1)
 		firing_burst = TRUE
 		for(var/i = 1 to burst_size)
-			addtimer(CALLBACK(src, PROC_REF(process_burst), user, target, message, params, zone_override, sprd, randomized_gun_spread, randomized_bonus_spread, rand_spr, i), real_fire_delay * (i - 1))
+			addtimer(CALLBACK(src, PROC_REF(process_burst), user, target, message, params, zone_override, sprd, randomized_gun_spread, randomized_bonus_spread, rand_spr, i), max(1, real_fire_delay * (i - 1)))
 	else
 		if(chambered)
 			if(HAS_TRAIT(user, TRAIT_PACIFISM)) // If the user has the pacifist trait, then they won't be able to fire [src] if the round chambered inside of [src] is lethal.

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -322,10 +322,8 @@
 	var/randomized_bonus_spread = rand(0, bonus_spread)
 
 	var/real_fire_delay = fire_delay
-	if(ishuman(user))
-		var/mob/living/carbon/human/shooter = user
-		if(shooter.halved_fire_delay)
-			real_fire_delay /= 2
+	if(HAS_TRAIT(user, TRAIT_GUNFIGHTER))
+		real_fire_delay /= 2
 
 	if(burst_size > 1)
 		firing_burst = TRUE

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -322,8 +322,10 @@
 	var/randomized_bonus_spread = rand(0, bonus_spread)
 
 	var/real_fire_delay = fire_delay
-	if(user.halved_fire_delay)
-		real_fire_delay /= 2
+	if(ishuman(user))
+		var/mob/living/carbon/human/shooter = user
+		if(shooter.halved_fire_delay)
+			real_fire_delay /= 2
 
 	if(burst_size > 1)
 		firing_burst = TRUE

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -322,8 +322,8 @@
 	var/randomized_bonus_spread = rand(0, bonus_spread)
 
 	var/real_fire_delay = fire_delay
-	if(user.no_fire_delay)
-		real_fire_delay = 0
+	if(user.halved_fire_delay)
+		real_fire_delay /= 2
 
 	if(burst_size > 1)
 		firing_burst = TRUE

--- a/code/modules/vtmb/archetypes.dm
+++ b/code/modules/vtmb/archetypes.dm
@@ -50,7 +50,7 @@
 	start_blood = 2
 
 /datum/archetype/gunfighter/special_skill(var/mob/living/carbon/human/H)
-	H.no_fire_delay = TRUE
+	H.halved_fire_delay = TRUE
 
 /datum/archetype/diplomatic
 	name = "Diplomatic"

--- a/code/modules/vtmb/archetypes.dm
+++ b/code/modules/vtmb/archetypes.dm
@@ -50,7 +50,7 @@
 	start_blood = 2
 
 /datum/archetype/gunfighter/special_skill(var/mob/living/carbon/human/H)
-	H.halved_fire_delay = TRUE
+	ADD_TRAIT(H, TRAIT_GUNFIGHTER, TRAUMA_TRAIT)
 
 /datum/archetype/diplomatic
 	name = "Diplomatic"

--- a/code/modules/vtmb/archetypes.dm
+++ b/code/modules/vtmb/archetypes.dm
@@ -50,7 +50,7 @@
 	start_blood = 2
 
 /datum/archetype/gunfighter/special_skill(var/mob/living/carbon/human/H)
-	ADD_TRAIT(H, TRAIT_GUNFIGHTER, TRAUMA_TRAIT)
+	ADD_TRAIT(H, TRAIT_GUNFIGHTER, ROUNDSTART_TRAIT)
 
 /datum/archetype/diplomatic
 	name = "Diplomatic"
@@ -68,7 +68,7 @@
 	start_physique = 3
 
 /datum/archetype/masochist/special_skill(var/mob/living/carbon/human/H)
-	ADD_TRAIT(H, TRAIT_NOSOFTCRIT, TRAUMA_TRAIT)
+	ADD_TRAIT(H, TRAIT_NOSOFTCRIT, ROUNDSTART_TRAIT)
 
 /datum/archetype/wiseman
 	name = "Wiseman"


### PR DESCRIPTION
## About The Pull Request
Changes the Gunfighter archetype's delay reduction from "basically no delay between shots" to "halved delay".
Slightly reworks the code so that it uses a trait instead of a variable.

## Why It's Good For The Game
It's somewhat more balanced. Rapid fire guns will still fire very fast but they should no longer literally fire like shotguns. Also makes sure the [buffed sniper rifle](https://github.com/WorldOfDarknessXIII/World-of-Darkness-13/pull/607) does not become OP (its main drawback is a 4 second delay between shots which gets removed with Gunfighter).

## Changelog
:cl:
balance: The Gunfighter archetype now only reduces firing delays by half instead of removing them.
/:cl: