### PR TITLE
Removes all times CMNoir/greyscale-vision is set for ghost

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -371,7 +371,6 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 					message_admins("[key_name_admin(usr)] re-entered corpse")
 				ghost.can_reenter_corpse = TRUE //force re-entering even when otherwise not possible
 				ghost.client.show_popup_menus = 0
-				ghost.client.color = CMNoir
 				ghost.reenter_corpse()
 
 				SSblackbox.record_feedback("tally", "admin_verb", 1, "Admin Reenter") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -72,11 +72,6 @@ var/list/CMNoir = list(0.3,0.3,0.3,0,\
 	var/aghosted = FALSE
 	var/auspex_ghosted = FALSE
 
-/mob/dead/observer/Login()
-	..()
-//There was observer music here. It's gone now.
-//Also ghost greyscaling, straining for the eyes.
-
 /mob/dead/observer/Initialize()
 	set_invisibility(GLOB.observer_default_invisibility)
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -74,10 +74,8 @@ var/list/CMNoir = list(0.3,0.3,0.3,0,\
 
 /mob/dead/observer/Login()
 	..()
-	if(client && !aghosted)
-		animate(client, color = CMNoir, time = 30)
-		client.color = CMNoir
 //There was observer music here. It's gone now.
+//Also ghost greyscaling, straining for the eyes.
 
 /mob/dead/observer/Initialize()
 	set_invisibility(GLOB.observer_default_invisibility)
@@ -319,7 +317,6 @@ Works together with spawning an observer, noted above.
 		// [ChillRaccoon] - setting mob icons
 		ghost.icon = src.icon // [ChillRaccoon] - We should transfer mob visuals to the ghost
 		ghost.overlays = src.overlays // [ChillRaccoon] - Overlays too, else we will not see wounds, hair, skin, and etc.
-		ghost.color = CMNoir // [ChillRaccoon] - it makes our ghost looks like noir
 		// -------
 		ghost.key = key
 		ghost.client.init_verbs()

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -54,8 +54,6 @@ GLOBAL_LIST_EMPTY(dead_players_during_shift)
 				call_dharma("judgement", U)
 			if(!(real_name in U.mind?.dharma?.deserving) && U.real_name == lastattacker)
 				call_dharma("killfirst", U)
-	if(client)
-		animate(client, color = CMNoir, time = 10) // [ChillRaccoon] - make life/death transition looks more beauty
 	to_chat(src, "<span class='warning'>You have died. Barring complete bodyloss, you can in most cases be revived by other players. If you do not wish to be brought back, use the \"Do Not Resuscitate\" verb in the ghost tab.</span>")
 
 /mob/living/carbon/human/proc/makeSkeleton()


### PR DESCRIPTION
## About The Pull Request
Removes all times ghost vision is set to or animated towards CMNoir greyscale-o-vision.
Keeps the CMNoir color matrix list incase of future use.

Gif of it not greyscaling your screen when you ghost
![dreamseeker_2025-01-28_17-03-03](https://github.com/user-attachments/assets/bcd91ddf-ef93-4556-b42d-4006cbdf5634)
## Why It's Good For The Game
To be admittedly rather brash, the greyscale vision just makes observing worse, it doesn't add any flavor or theme or any other since of aesthetic but rather wears and tears on your eyes as you try to look at the cool stuff thats happening through a faded lens. Best case it's a nuisance and makes any recording of in-game footage from a ghost/observer perspective hard to look at and at worst it just drives people away from staying to observe or atleast be more interested in a game they're not directly participating in.

## Changelog
:cl: Vondiech/Citruses
del: Ghost greyscale vision is no more.
/:cl:
