### PR TITLE
Removed diseases from rotten corpses and organs

### DIFF
--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -395,13 +395,6 @@
 		if (breath_gases[/datum/gas/miasma])
 			var/miasma_pp = breath.get_breath_partial_pressure(breath_gases[/datum/gas/miasma][MOLES])
 
-			//Miasma sickness
-			if(prob(0.5 * miasma_pp))
-				var/datum/disease/advance/miasma_disease = new /datum/disease/advance/random(min(round(max(miasma_pp/2, 1), 1), 6), min(round(max(miasma_pp, 1), 1), 8))
-				//tl;dr the first argument chooses the smaller of miasma_pp/2 or 6(typical max virus symptoms), the second chooses the smaller of miasma_pp or 8(max virus symptom level) //
-				miasma_disease.name = "Unknown"//^each argument has a minimum of 1 and rounds to the nearest value. Feel free to change the pp scaling I couldn't decide on good numbers for it.
-				miasma_disease.try_infect(owner)
-
 			// Miasma side effects
 			switch(miasma_pp)
 				if(0.25 to 5)


### PR DESCRIPTION


## About The Pull Request

Removed diseases from rotten corpses and organs, cuz it doesn't add anything to the gameplay and all diseases require reagents that we don't have

Removed it without commenting as we're getting rid of athmos soon anyway

## Changelog
directly removed miasma sickness

