### PR TITLE
Fixes Oversight & Makes more things orderable at the Dealer

### DIFF
--- a/code/modules/wod13/cargo.dm
+++ b/code/modules/wod13/cargo.dm
@@ -31,6 +31,13 @@
 	contains = list(/obj/item/drinkable_bloodpack, /obj/item/drinkable_bloodpack, /obj/item/drinkable_bloodpack, /obj/item/drinkable_bloodpack, /obj/item/drinkable_bloodpack)
 	crate_name = "blood crate"
 
+/datum/supply_pack/vampire/bloodpack_elite
+	name = "Elite Blood Pack"
+	desc = "Contains 5 elite blood packs."
+	cost = 300
+	contains = list(/obj/item/drinkable_bloodpack/elite, /obj/item/drinkable_bloodpack/elite, /obj/item/drinkable_bloodpack/elite, /obj/item/drinkable_bloodpack/elite, /obj/item/drinkable_bloodpack/elite)
+	crate_name = "blood crate"
+
 /datum/supply_pack/vampire/weaponstake
 	name = "Weapon (stake)"
 	desc = "Contains 3 usable wooden stakes."
@@ -65,13 +72,6 @@
 	cost = 300
 	contains = list(/obj/item/melee/vampirearms/shovel)
 	crate_name = "weapon crate"
-
-/datum/supply_pack/vampire/bloodpack_elite
-	name = "Elite Blood Pack"
-	desc = "Contains 5 elite blood packs."
-	cost = 300
-	contains = list(/obj/item/drinkable_bloodpack/elite, /obj/item/drinkable_bloodpack/elite, /obj/item/drinkable_bloodpack/elite, /obj/item/drinkable_bloodpack/elite, /obj/item/drinkable_bloodpack/elite)
-	crate_name = "blood crate"
 
 /datum/supply_pack/vampire/weaponbaseball
 	name = "Weapon (baseball bat)"
@@ -228,42 +228,42 @@
 	name = "Ammo (9mm)"
 	desc = "Contains a box of 9mm ammunition."
 	cost = 200
-	contains = list(/obj/item/ammo_box/vampire/c9mm)
+	contains = list(/obj/item/ammo_box/vampire/c9mm, /obj/item/ammo_box/vampire/c9mm)
 	crate_name = "ammo crate"
 
 /datum/supply_pack/vampire/ammo12g
 	name = "Ammo (12g, slug)"
 	desc = "Contains a box of 12 gauge shotgun slugs."
 	cost = 400
-	contains = list(/obj/item/ammo_box/vampire/c12g)
+	contains = list(/obj/item/ammo_box/vampire/c12g, /obj/item/ammo_box/vampire/c12g)
 	crate_name = "ammo crate"
 
 /datum/supply_pack/vampire/ammo12gbuck
 	name = "Ammo (12g, buckshot)"
 	desc = "Contains a box of 12g 00 buckshot shells."
 	cost = 400
-	contains = list(/obj/item/ammo_box/vampire/c12g/buck)
+	contains = list(/obj/item/ammo_box/vampire/c12g/buck, /obj/item/ammo_box/vampire/c12g/buck)
 	crate_name = "ammo crate"
 
 /datum/supply_pack/vampire/ammo545
 	name = "Ammo (5.45)"
 	desc = "Contains a box of 5.45 ammunition."
 	cost = 500
-	contains = list(/obj/item/ammo_box/vampire/c545)
+	contains = list(/obj/item/ammo_box/vampire/c545, /obj/item/ammo_box/vampire/c545)
 	crate_name = "ammo crate"
 
 /datum/supply_pack/vampire/ammo44
 	name = "Ammo (.44)"
 	desc = "Contains a box of .44 ammunition."
 	cost = 600
-	contains = list(/obj/item/ammo_box/vampire/c44)
+	contains = list(/obj/item/ammo_box/vampire/c44, /obj/item/ammo_box/vampire/c44)
 	crate_name = "ammo crate"
 
 /datum/supply_pack/vampire/ammo556
 	name = "Ammo (5.56)"
 	desc = "Contains a box of 5.56 ammunition."
 	cost = 1500
-	contains = list(/obj/item/ammo_box/vampire/c556)
+	contains = list(/obj/item/ammo_box/vampire/c556, /obj/item/ammo_box/vampire/c556)
 	crate_name = "ammo crate"
 
 /datum/supply_pack/vampire/ammo9/silver
@@ -305,70 +305,70 @@
 	name = "Ammo (bolts)"
 	desc = "Contains a box of crossbow ammunition."
 	cost = 600
-	contains = list(/obj/item/ammo_box/vampire/arrows)
+	contains = list(/obj/item/ammo_box/vampire/arrows, /obj/item/ammo_box/vampire/arrows, /obj/item/ammo_box/vampire/arrows)
 	crate_name = "ammo crate"
 
 /datum/supply_pack/vampire/magazine_colt1911
 	name = "Ammo (Colt M1911 magazine)"
 	desc = "Contains a Colt M1911 magazine."
 	cost = 50
-	contains = list(/obj/item/ammo_box/magazine/vamp45acp)
+	contains = list(/obj/item/ammo_box/magazine/vamp45acp, /obj/item/ammo_box/magazine/vamp45acp, /obj/item/ammo_box/magazine/vamp45acp)
 	crate_name = "ammo crate"
 
 /datum/supply_pack/vampire/magazine_glock19
 	name = "Ammo (Glock19 magazine)"
 	desc = "Contains a Glock19 magazine."
 	cost = 100
-	contains = list(/obj/item/ammo_box/magazine/glock9mm)
+	contains = list(/obj/item/ammo_box/magazine/glock9mm, /obj/item/ammo_box/magazine/glock9mm, /obj/item/ammo_box/magazine/glock9mm)
 	crate_name = "ammo crate"
 
 /datum/supply_pack/vampire/magazine_ak74
 	name = "Ammo (AK74 magazine)"
 	desc = "Contains an AK74 magazine."
 	cost = 100
-	contains = list(/obj/item/ammo_box/magazine/vamp545)
+	contains = list(/obj/item/ammo_box/magazine/vamp545, /obj/item/ammo_box/magazine/vamp545, /obj/item/ammo_box/magazine/vamp545)
 	crate_name = "ammo crate"
 
 /datum/supply_pack/vampire/magazine_deagle
 	name = "Ammo (desert eagle magazine)"
 	desc = "Contains a desert eagle magazine."
 	cost = 100
-	contains = list(/obj/item/ammo_box/magazine/m44)
+	contains = list(/obj/item/ammo_box/magazine/m44, /obj/item/ammo_box/magazine/m44, /obj/item/ammo_box/magazine/m44)
 	crate_name = "ammo crate"
 
 /datum/supply_pack/vampire/magazine_mp5
 	name = "Ammo (HK MP5 magazine)"
 	desc = "Contains an HK MP5 magazine."
 	cost = 150
-	contains = list(/obj/item/ammo_box/magazine/vamp9mp5)
+	contains = list(/obj/item/ammo_box/magazine/vamp9mp5, /obj/item/ammo_box/magazine/vamp9mp5, /obj/item/ammo_box/magazine/vamp9mp5)
 	crate_name = "ammo crate"
 
 /datum/supply_pack/vampire/magazine_uzi
 	name = "Ammo (mini uzi magazine)"
 	desc = "Contains a mini uzi magazine."
 	cost = 200
-	contains = list(/obj/item/ammo_box/magazine/vamp9mm)
+	contains = list(/obj/item/ammo_box/magazine/vamp9mm, /obj/item/ammo_box/magazine/vamp9mm, /obj/item/ammo_box/magazine/vamp9mm)
 	crate_name = "ammo crate"
 
 /datum/supply_pack/vampire/magazine_ar15
 	name = "Ammo (AR-15 rifle magazine)"
 	desc = "Contains an AR-15 rifle magazine."
 	cost = 200
-	contains = list(/obj/item/ammo_box/magazine/vamp556)
+	contains = list(/obj/item/ammo_box/magazine/vamp556, /obj/item/ammo_box/magazine/vamp556, /obj/item/ammo_box/magazine/vamp556)
 	crate_name = "ammo crate"
 
 /datum/supply_pack/vampire/magazine_aug
 	name = "Ammo (AUG carbine magazine)"
 	desc = "Contains an AUG carbine magazine."
 	cost = 300
-	contains = list(/obj/item/ammo_box/magazine/vampaug)
+	contains = list(/obj/item/ammo_box/magazine/vampaug, /obj/item/ammo_box/magazine/vampaug, /obj/item/ammo_box/magazine/vampaug)
 	crate_name = "ammo crate"
 
 /datum/supply_pack/vampire/magazine_thompson
 	name = "Ammo (Thompson magazine)"
 	desc = "Contains a Thompson magazine."
 	cost = 300
-	contains = list(/obj/item/ammo_box/magazine/vampthompson)
+	contains = list(/obj/item/ammo_box/magazine/vampthompson, /obj/item/ammo_box/magazine/vampthompson, /obj/item/ammo_box/magazine/vampthompson)
 	crate_name = "ammo crate"
 
 /datum/supply_pack/vampire/armorlight

--- a/code/modules/wod13/cargo.dm
+++ b/code/modules/wod13/cargo.dm
@@ -1,6 +1,4 @@
-
-/datum/supply_pack/vampire/weedsupplies
-	name = "Box of Hydroponics Supplies"
+/datum/supply_pack/vampire/weed_supplies
 	desc = "Contains a bailer and some seeds. No trays."
 	cost = 100
 	contains = list(/obj/item/bailer, /obj/item/weedseed, /obj/item/weedseed, /obj/item/weedseed, /obj/item/weedseed, /obj/item/weedseed)
@@ -13,43 +11,11 @@
 	contains = list(/obj/structure/weedshit/buyable)
 	crate_name = "weed crate"
 
-/datum/supply_pack/vampire/thermal_drill
-	name = "Thermal Drill"
-	desc = "Contains a thermal drill."
-	cost = 4000
-	contains = list(/obj/structure/drill)
-	crate_name = "drill crate"
-
-/datum/supply_pack/vampire/potassiodide
-	name = "Potassium Iodide"
-	desc = "Contains bottle of potassium iodide."
-	cost = 400
-	contains = list(/obj/item/storage/pill_bottle/potassiodide)
-
 /datum/supply_pack/vampire/methlab
 	name = "Lab Equipment"
 	desc = "Contains lab equipment."
 	cost = 10000
 	contains = list(/obj/structure/methlab/movable)
-
-/datum/supply_pack/vampire/gas_can
-	name = "Gas Can"
-	desc = "Contains a gas can."
-	cost = 400
-	contains = list(/obj/item/gas_can/full)
-
-/datum/supply_pack/vampire/ephedrine
-	name = "Ephedrine"
-	desc = "Contains bottle of ephedrine."
-	cost = 400
-	contains = list(/obj/item/storage/pill_bottle/ephedrine)
-
-/datum/supply_pack/vampire/cuffs
-	name = "Box of Handcuffs"
-	desc = "Contains a box of handcuffs."
-	cost = 150
-	contains = list(/obj/item/storage/box/handcuffs)
-	crate_name = "handcuff crate"
 
 /datum/supply_pack/vampire/fixing
 	name = "Fixing kit (wirecutters, lamps)"
@@ -63,13 +29,6 @@
 	desc = "Contains 5 default blood packs."
 	cost = 100
 	contains = list(/obj/item/drinkable_bloodpack, /obj/item/drinkable_bloodpack, /obj/item/drinkable_bloodpack, /obj/item/drinkable_bloodpack, /obj/item/drinkable_bloodpack)
-	crate_name = "blood crate"
-
-/datum/supply_pack/vampire/bloodpack_elite
-	name = "Elite Blood Pack"
-	desc = "Contains 5 elite blood packs."
-	cost = 300
-	contains = list(/obj/item/drinkable_bloodpack/elite, /obj/item/drinkable_bloodpack/elite, /obj/item/drinkable_bloodpack/elite, /obj/item/drinkable_bloodpack/elite, /obj/item/drinkable_bloodpack/elite)
 	crate_name = "blood crate"
 
 /datum/supply_pack/vampire/weaponstake
@@ -93,6 +52,13 @@
 	contains = list(/obj/item/melee/vampirearms/tire)
 	crate_name = "weapon crate"
 
+/datum/supply_pack/vampire/cuffs
+	name = "Box of Handcuffs"
+	desc = "Contains a box of handcuffs."
+	cost = 150
+	contains = list(/obj/item/storage/box/handcuffs)
+	crate_name = "handcuff crate"
+
 /datum/supply_pack/vampire/weaponshovel
 	name = "Weapon (shovel)"
 	desc = "Contains a shovel."
@@ -100,12 +66,37 @@
 	contains = list(/obj/item/melee/vampirearms/shovel)
 	crate_name = "weapon crate"
 
+/datum/supply_pack/vampire/bloodpack_elite
+	name = "Elite Blood Pack"
+	desc = "Contains 5 elite blood packs."
+	cost = 300
+	contains = list(/obj/item/drinkable_bloodpack/elite, /obj/item/drinkable_bloodpack/elite, /obj/item/drinkable_bloodpack/elite, /obj/item/drinkable_bloodpack/elite, /obj/item/drinkable_bloodpack/elite)
+	crate_name = "blood crate"
+
 /datum/supply_pack/vampire/weaponbaseball
 	name = "Weapon (baseball bat)"
 	desc = "Contains a baseball bat."
 	cost = 400
 	contains = list(/obj/item/melee/vampirearms/baseball)
 	crate_name = "weapon crate"
+
+/datum/supply_pack/vampire/potassiodide
+	name = "Potassium Iodide"
+	desc = "Contains bottle of potassium iodide."
+	cost = 400
+	contains = list(/obj/item/storage/pill_bottle/potassiodide)
+
+/datum/supply_pack/vampire/ephedrine
+	name = "Ephedrine"
+	desc = "Contains bottle of ephedrine."
+	cost = 400
+	contains = list(/obj/item/storage/pill_bottle/ephedrine)
+
+/datum/supply_pack/vampire/gas_can
+	name = "Gas Can"
+	desc = "Contains a gas can."
+	cost = 400
+	contains = list(/obj/item/gas_can/full)
 
 /datum/supply_pack/vampire/weaponfireaxe
 	name = "Weapon (fire axe)"
@@ -177,46 +168,11 @@
 	contains = list(/obj/item/gun/ballistic/automatic/vampire/uzi, /obj/item/ammo_box/magazine/vamp9mm)
 	crate_name = "weapon crate"
 
-/datum/supply_pack/vampire/weaponrifle
-	name = "Weapon (assault rifle)"
-	desc = "Contains an assault rifle."
-	cost = 3000
-	contains = list(/obj/item/gun/ballistic/automatic/vampire/ar15, /obj/item/ammo_box/magazine/vamp556)
-	crate_name = "weapon crate"
-
-/datum/supply_pack/vampire/weaponcarbine
-	name = "Weapon (assault carbine)"
-	desc = "Contains an assault carbine."
-	cost = 4000
-	contains = list(/obj/item/gun/ballistic/automatic/vampire/aug, /obj/item/ammo_box/magazine/vampaug)
-	crate_name = "weapon crate"
-
 /datum/supply_pack/vampire/weaponshotgun
 	name = "Weapon (pomp shotgun)"
 	desc = "Contains a pomp shotgun."
 	cost = 800
 	contains = list(/obj/item/gun/ballistic/shotgun/vampire)
-	crate_name = "weapon crate"
-
-/datum/supply_pack/vampire/weaponsniper
-	name = "Weapon (sniper rifle)"
-	desc = "Contains a sniper rifle."
-	cost = 2000
-	contains = list(/obj/item/gun/ballistic/automatic/vampire/sniper)
-	crate_name = "weapon crate"
-
-/datum/supply_pack/vampire/weaponcrossbow
-	name = "Weapon (crossbow)"
-	desc = "Contains a crossbow."
-	cost = 1000
-	contains = list(/obj/item/gun/ballistic/shotgun/toy/crossbow/vampire)
-	crate_name = "weapon crate"
-
-/datum/supply_pack/vampire/ak74
-	name = "Weapon (AK-74)"
-	desc = "Contains an AK-74."
-	cost = 2200
-	contains = list(/obj/item/gun/ballistic/automatic/vampire/ak74)
 	crate_name = "weapon crate"
 
 /datum/supply_pack/vampire/thompson
@@ -233,60 +189,46 @@
 	contains = list(/obj/item/gun/ballistic/automatic/vampire/mp5)
 	crate_name = "weapon crate"
 
+/datum/supply_pack/vampire/ak74
+	name = "Weapon (AK-74)"
+	desc = "Contains an AK-74."
+	cost = 2200
+	contains = list(/obj/item/gun/ballistic/automatic/vampire/ak74)
+	crate_name = "weapon crate"
+
+/datum/supply_pack/vampire/weaponrifle
+	name = "Weapon (assault rifle)"
+	desc = "Contains an assault rifle."
+	cost = 3000
+	contains = list(/obj/item/gun/ballistic/automatic/vampire/ar15, /obj/item/ammo_box/magazine/vamp556)
+	crate_name = "weapon crate"
+
+/datum/supply_pack/vampire/weaponcarbine
+	name = "Weapon (assault carbine)"
+	desc = "Contains an assault carbine."
+	cost = 4000
+	contains = list(/obj/item/gun/ballistic/automatic/vampire/aug, /obj/item/ammo_box/magazine/vampaug)
+	crate_name = "weapon crate"
+
+/datum/supply_pack/vampire/weaponcrossbow
+	name = "Weapon (crossbow)"
+	desc = "Contains a crossbow."
+	cost = 1000
+	contains = list(/obj/item/gun/ballistic/shotgun/toy/crossbow/vampire)
+	crate_name = "weapon crate"
+
+/datum/supply_pack/vampire/weaponsniper
+	name = "Weapon (sniper rifle)"
+	desc = "Contains a sniper rifle."
+	cost = 2000
+	contains = list(/obj/item/gun/ballistic/automatic/vampire/sniper)
+	crate_name = "weapon crate"
+
 /datum/supply_pack/vampire/ammo9
 	name = "Ammo (9mm)"
 	desc = "Contains a box of 9mm ammunition."
 	cost = 200
 	contains = list(/obj/item/ammo_box/vampire/c9mm)
-	crate_name = "ammo crate"
-
-/datum/supply_pack/vampire/ammo9/silver
-	name = "Ammo (9mm, silver)"
-	desc = "Contains a box of silver 9mm ammunition."
-	cost = 2000
-	contains = list(/obj/item/ammo_box/vampire/c9mm/silver)
-	crate_name = "ammo crate"
-
-/datum/supply_pack/vampire/ammo44
-	name = "Ammo (.44)"
-	desc = "Contains a box of .44 ammunition."
-	cost = 600
-	contains = list(/obj/item/ammo_box/vampire/c44)
-	crate_name = "ammo crate"
-
-/datum/supply_pack/vampire/ammo44/silver
-	name = "Ammo (.44, silver)"
-	desc = "Contains a box of silver .44 ammunition."
-	cost = 2000
-	contains = list(/obj/item/ammo_box/vampire/c44/silver)
-	crate_name = "ammo crate"
-
-/datum/supply_pack/vampire/ammo45/silver
-	name = "Ammo (.45, silver)"
-	desc = "Contains a box of silver .45 ammunition."
-	cost = 2000
-	contains = list(/obj/item/ammo_box/vampire/c45acp/silver)
-	crate_name = "ammo crate"
-
-/datum/supply_pack/vampire/ammo556
-	name = "Ammo (5.56)"
-	desc = "Contains a box of 5.56 ammunition."
-	cost = 1500
-	contains = list(/obj/item/ammo_box/vampire/c556)
-	crate_name = "ammo crate"
-
-/datum/supply_pack/vampire/ammo556/incendiart
-	name = "Ammo (5.56 incendiary)"
-	desc = "Contains a box of incendiary 5.56 ammunition."
-	cost = 4500
-	contains = list(/obj/item/ammo_box/vampire/c556/incendiary)
-	crate_name = "ammo crate"
-
-/datum/supply_pack/vampire/ammo556/silver
-	name = "Ammo (5.56, silver)"
-	desc = "Contains a box of silver 5.56 ammunition."
-	cost = 3000
-	contains = list(/obj/item/ammo_box/vampire/c556/silver)
 	crate_name = "ammo crate"
 
 /datum/supply_pack/vampire/ammo12g
@@ -303,13 +245,6 @@
 	contains = list(/obj/item/ammo_box/vampire/c12g/buck)
 	crate_name = "ammo crate"
 
-/datum/supply_pack/vampire/ammobolt
-	name = "Ammo (bolts)"
-	desc = "Contains a box of crossbow ammunition."
-	cost = 600
-	contains = list(/obj/item/ammo_box/vampire/arrows)
-	crate_name = "ammo crate"
-
 /datum/supply_pack/vampire/ammo545
 	name = "Ammo (5.45)"
 	desc = "Contains a box of 5.45 ammunition."
@@ -317,11 +252,81 @@
 	contains = list(/obj/item/ammo_box/vampire/c545)
 	crate_name = "ammo crate"
 
-/datum/supply_pack/vampire/magazine_uzi
-	name = "Ammo (mini uzi magazine)"
-	desc = "Contains a mini uzi magazine."
-	cost = 200
-	contains = list(/obj/item/ammo_box/magazine/vamp9mm)
+/datum/supply_pack/vampire/ammo44
+	name = "Ammo (.44)"
+	desc = "Contains a box of .44 ammunition."
+	cost = 600
+	contains = list(/obj/item/ammo_box/vampire/c44)
+	crate_name = "ammo crate"
+
+/datum/supply_pack/vampire/ammo556
+	name = "Ammo (5.56)"
+	desc = "Contains a box of 5.56 ammunition."
+	cost = 1500
+	contains = list(/obj/item/ammo_box/vampire/c556)
+	crate_name = "ammo crate"
+
+/datum/supply_pack/vampire/ammo9/silver
+	name = "Ammo (9mm, silver)"
+	desc = "Contains a box of silver 9mm ammunition."
+	cost = 2000
+	contains = list(/obj/item/ammo_box/vampire/c9mm/silver)
+	crate_name = "ammo crate"
+
+/datum/supply_pack/vampire/ammo44/silver
+	name = "Ammo (.44, silver)"
+	desc = "Contains a box of silver .44 ammunition."
+	cost = 2000
+	contains = list(/obj/item/ammo_box/vampire/c44/silver)
+	crate_name = "ammo crate"
+
+/datum/supply_pack/vampire/ammo45/silver
+	name = "Ammo (.45, silver)"
+	desc = "Contains a box of silver .45 ammunition."
+	cost = 2000
+	contains = list(/obj/item/ammo_box/vampire/c45acp/silver)
+	crate_name = "ammo crate"
+
+/datum/supply_pack/vampire/ammo556/silver
+	name = "Ammo (5.56, silver)"
+	desc = "Contains a box of silver 5.56 ammunition."
+	cost = 3000
+	contains = list(/obj/item/ammo_box/vampire/c556/silver)
+	crate_name = "ammo crate"
+
+/datum/supply_pack/vampire/ammo556/incendiart
+	name = "Ammo (5.56 incendiary)"
+	desc = "Contains a box of incendiary 5.56 ammunition."
+	cost = 4500
+	contains = list(/obj/item/ammo_box/vampire/c556/incendiary)
+	crate_name = "ammo crate"
+
+/datum/supply_pack/vampire/ammobolt
+	name = "Ammo (bolts)"
+	desc = "Contains a box of crossbow ammunition."
+	cost = 600
+	contains = list(/obj/item/ammo_box/vampire/arrows)
+	crate_name = "ammo crate"
+
+/datum/supply_pack/vampire/magazine_colt1911
+	name = "Ammo (Colt M1911 magazine)"
+	desc = "Contains a Colt M1911 magazine."
+	cost = 50
+	contains = list(/obj/item/ammo_box/magazine/vamp45acp)
+	crate_name = "ammo crate"
+
+/datum/supply_pack/vampire/magazine_glock19
+	name = "Ammo (Glock19 magazine)"
+	desc = "Contains a Glock19 magazine."
+	cost = 100
+	contains = list(/obj/item/ammo_box/magazine/glock9mm)
+	crate_name = "ammo crate"
+
+/datum/supply_pack/vampire/magazine_ak74
+	name = "Ammo (AK74 magazine)"
+	desc = "Contains an AK74 magazine."
+	cost = 100
+	contains = list(/obj/item/ammo_box/magazine/vamp545)
 	crate_name = "ammo crate"
 
 /datum/supply_pack/vampire/magazine_deagle
@@ -329,6 +334,20 @@
 	desc = "Contains a desert eagle magazine."
 	cost = 100
 	contains = list(/obj/item/ammo_box/magazine/m44)
+	crate_name = "ammo crate"
+
+/datum/supply_pack/vampire/magazine_mp5
+	name = "Ammo (HK MP5 magazine)"
+	desc = "Contains an HK MP5 magazine."
+	cost = 150
+	contains = list(/obj/item/ammo_box/magazine/vamp9mp5)
+	crate_name = "ammo crate"
+
+/datum/supply_pack/vampire/magazine_uzi
+	name = "Ammo (mini uzi magazine)"
+	desc = "Contains a mini uzi magazine."
+	cost = 200
+	contains = list(/obj/item/ammo_box/magazine/vamp9mm)
 	crate_name = "ammo crate"
 
 /datum/supply_pack/vampire/magazine_ar15
@@ -350,34 +369,6 @@
 	desc = "Contains a Thompson magazine."
 	cost = 300
 	contains = list(/obj/item/ammo_box/magazine/vampthompson)
-	crate_name = "ammo crate"
-
-/datum/supply_pack/vampire/magazine_ak74
-	name = "Ammo (AK74 magazine)"
-	desc = "Contains an AK74 magazine."
-	cost = 100
-	contains = list(/obj/item/ammo_box/magazine/vamp545)
-	crate_name = "ammo crate"
-
-/datum/supply_pack/vampire/magazine_mp5
-	name = "Ammo (HK MP5 magazine)"
-	desc = "Contains an HK MP5 magazine."
-	cost = 150
-	contains = list(/obj/item/ammo_box/magazine/vamp9mp5)
-	crate_name = "ammo crate"
-
-/datum/supply_pack/vampire/magazine_glock19
-	name = "Ammo (Glock19 magazine)"
-	desc = "Contains a Glock19 magazine."
-	cost = 100
-	contains = list(/obj/item/ammo_box/magazine/glock9mm)
-	crate_name = "ammo crate"
-
-/datum/supply_pack/vampire/magazine_colt1911
-	name = "Ammo (Colt M1911 magazine)"
-	desc = "Contains a Colt M1911 magazine."
-	cost = 50
-	contains = list(/obj/item/ammo_box/magazine/vamp45acp)
 	crate_name = "ammo crate"
 
 /datum/supply_pack/vampire/armorlight
@@ -415,6 +406,13 @@
 	contains = list(/obj/item/clothing/suit/vampire/eod,
 					/obj/item/clothing/head/vampire/eod)
 	crate_name = "armor crate"
+
+/datum/supply_pack/vampire/thermal_drill
+	name = "Thermal Drill"
+	desc = "Contains a thermal drill."
+	cost = 4000
+	contains = list(/obj/structure/drill)
+	crate_name = "drill crate"
 
 /obj/item/stack/dollar
 	name = "dollars"

--- a/code/modules/wod13/cargo.dm
+++ b/code/modules/wod13/cargo.dm
@@ -1,3 +1,11 @@
+
+/datum/supply_pack/vampire/weedsupplies
+	name = "Box of Hydroponics Supplies"
+	desc = "Contains a bailer and some seeds. No trays."
+	cost = 100
+	contains = list(/obj/item/bailer, /obj/item/weedseed, /obj/item/weedseed, /obj/item/weedseed, /obj/item/weedseed, /obj/item/weedseed)
+	crate_name = "hydro supplies"
+
 /datum/supply_pack/vampire/weed_tray
 	name = "Weed Tray"
 	desc = "Contains a tray of weed."

--- a/code/modules/wod13/cargo.dm
+++ b/code/modules/wod13/cargo.dm
@@ -4,7 +4,7 @@
 	desc = "Contains a bailer and some seeds. No trays."
 	cost = 100
 	contains = list(/obj/item/bailer, /obj/item/weedseed, /obj/item/weedseed, /obj/item/weedseed, /obj/item/weedseed, /obj/item/weedseed)
-	crate_name = "hydro supplies"
+	crate_name = "hydro crate"
 
 /datum/supply_pack/vampire/weed_tray
 	name = "Weed Tray"

--- a/code/modules/wod13/food.dm
+++ b/code/modules/wod13/food.dm
@@ -528,6 +528,8 @@
 	prize_list = list(
 		new /datum/data/mining_equipment("lighter",		/obj/item/lighter/greyscale,	10),
 		new /datum/data/mining_equipment("zippo lighter",	/obj/item/lighter,	20),
+		new /datum/data/mining_equipment("Bailer", /obj/item/bailer, 20),
+		new /datum/data/mining_equipment("Weed Seed", /obj/item/weedseed, 20),
 		new /datum/data/mining_equipment("cannabis puff",		/obj/item/clothing/mask/cigarette/rollie/cannabis,	40),
 		new /datum/data/mining_equipment("bong",	/obj/item/bong,		50),
 		new /datum/data/mining_equipment("lockpick",	/obj/item/vamp/keys/hack, 50),


### PR DESCRIPTION
## About The Pull Request
Fixes an oversight from my last PR. The sorting of the vendors caused me to remove the seeds and bailers so now you can get them. Also it sorts the Cargo Vendor from lowest to highest by category & lets magazines be ordered in bulk so you have reason to go to the Dealer too. Silver & Incen cost isn't touched though.

## Why It's Good For The Game

Fixes oversight, less extensive charging.

## Changelog

:cl:
Readds bailers and seeds to the BMD
Makes them orderable too
Sorts the Dealer Cargo Terminal
Makes it so you get more magazines in bulk cost
:cl: 