### PR TITLE
Recycler no longer deletes itself

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -201,7 +201,6 @@
 	// Instantly lie down, also go unconscious from the pain, before you die.
 	L.Unconscious(100)
 	L.adjustBruteLoss(crush_damage)
-	qdel(src)
 
 /obj/machinery/recycler/deathtrap
 	name = "dangerous old crusher"


### PR DESCRIPTION
## About The Pull Request
Makes the recycler no longer delete itself. This is most notable with the recycler in the restaurant's basement.

## Why It's Good For The Game
It makes the recycler reusable rather than cause it to magically disappear.

## Changelog
:cl:
fix: The recycler in the restaurant's basement will no longer delete itself upon shoving someone in it.
server: something server ops should know
/:cl: