### PR TITLE
Fixes ghost spawning triad soldiers not speaking Cantonese

### DIFF
--- a/code/modules/wod13/map.dm
+++ b/code/modules/wod13/map.dm
@@ -238,7 +238,7 @@
 	mob_name = "a triad soldier"
 	icon = 'icons/obj/lavaland/spawners.dmi'
 	icon_state = "cryostasis_sleeper"
-	outfit = /datum/outfit/triadsoldier
+	outfit = /datum/outfit/job/triad_soldier
 	roundstart = FALSE
 	death = FALSE
 	random = FALSE
@@ -256,19 +256,6 @@
 	var/my_surname = pick(GLOB.last_names_triad)
 	new_spawn.fully_replace_character_name(null,"[my_name] [my_surname]")
 
-/datum/outfit/triadsoldier
-	name = "triad soldier"
-	uniform = /obj/item/clothing/under/vampire/suit
-	shoes = /obj/item/clothing/shoes/vampire/jackboots
-//	suit = /obj/item/clothing/suit/vampire/vest
-//	belt = /obj/item/melee/classic_baton
-	id = /obj/item/cockclock
-	l_pocket = /obj/item/vamp/phone
-	r_pocket = /obj/item/flashlight
-	l_hand = /obj/item/vamp/keys/triads
-	r_hand = /obj/item/gun/ballistic/automatic/vampire/glock19
-	back = /obj/item/storage/backpack/satchel
-//
 /obj/effect/mob_spawn/human/police
 	name = "a police officer"
 	desc = "A humming sleeper with a silhouetted occupant inside. Its stasis function is broken and it's likely being used as a bed."


### PR DESCRIPTION
## About The Pull Request

Removes the duplicate triad soldier outfit and makes the ghost spawner role use the roundstarting outfit.

Testing:
- Launch the San Fransisco map
- Observe > Ghost > Spawners Menu
- a triad soldier (23 left) > Spawn
- Check the LANG menu on the left
- Check the backpack for the extra balaclava and knife

![image](https://github.com/user-attachments/assets/653188c1-cc91-411c-8911-06dcfa53dd03)

## Why It's Good For The Game

Bugs bad, this was reported on Discord

![image](https://github.com/user-attachments/assets/1b742ab7-89fb-4012-a3e8-fd4b214c83d7)

## Changelog

fix: Fixed triad soldiers spawning via the ghost spawner not speaking Cantonese. They now also spawn with an extra balaclava and a knife as the roundstart ones.