### PR TITLE
Gargoyle sight fix

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -400,11 +400,9 @@
 /datum/status_effect/duskndawn/on_apply()
 	. = ..()
 	ADD_TRAIT(owner,TRAIT_XRAY_VISION,type)
-	owner.update_sight()
 
 /datum/status_effect/duskndawn/on_remove()
 	REMOVE_TRAIT(owner,TRAIT_XRAY_VISION,type)
-	owner.update_sight()
 	return ..()
 
 /datum/status_effect/marshal

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -185,7 +185,6 @@
 
 		REMOVE_TRAIT(current_owner, TRAIT_SIXTHSENSE, SCRYING_ORB)
 		REMOVE_TRAIT(current_owner, TRAIT_XRAY_VISION, SCRYING_ORB)
-		current_owner.update_sight()
 
 		current_owner = null
 
@@ -196,7 +195,6 @@
 
 		ADD_TRAIT(current_owner, TRAIT_SIXTHSENSE, SCRYING_ORB)
 		ADD_TRAIT(current_owner, TRAIT_XRAY_VISION, SCRYING_ORB)
-		current_owner.update_sight()
 
 /obj/item/scrying/attack_self(mob/user)
 	visible_message("<span class='danger'>[user] stares into [src], their eyes glazing over.</span>")

--- a/code/modules/mob/living/carbon/init_signals.dm
+++ b/code/modules/mob/living/carbon/init_signals.dm
@@ -5,6 +5,15 @@
 	RegisterSignal(src, SIGNAL_ADDTRAIT(TRAIT_NOBREATH), PROC_REF(on_nobreath_trait_gain))
 	RegisterSignal(src, SIGNAL_ADDTRAIT(TRAIT_NOMETABOLISM), PROC_REF(on_nometabolism_trait_gain))
 
+	// Vision traits gain and removal
+	RegisterSignal(src, SIGNAL_ADDTRAIT(TRAIT_THERMAL_VISION), PROC_REF(on_thermal_vision_gain))
+	RegisterSignal(src, SIGNAL_ADDTRAIT(TRAIT_XRAY_VISION), PROC_REF(on_xray_vision_gain))
+	RegisterSignal(src, SIGNAL_ADDTRAIT(TRAIT_NIGHT_VISION), PROC_REF(on_night_vision_gain))
+
+	RegisterSignal(src, SIGNAL_REMOVETRAIT(TRAIT_THERMAL_VISION), PROC_REF(on_thermal_vision_loss))
+	RegisterSignal(src, SIGNAL_REMOVETRAIT(TRAIT_XRAY_VISION), PROC_REF(on_xray_vision_loss))
+	RegisterSignal(src, SIGNAL_REMOVETRAIT(TRAIT_NIGHT_VISION), PROC_REF(on_night_vision_loss))
+
 /**
  * On gain of TRAIT_NOBREATH
  *
@@ -42,3 +51,35 @@
 			LAZYREMOVE(reagents.addiction_list, R)
 			qdel(R)
 	reagents.end_metabolization(keep_liverless = TRUE)
+
+
+/*
+Handles vision trait updates:
+	TRAIT_THERMAL_VISION
+	TRAIT_XRAY_VISION
+	TRAIT_NIGHT_VISION
+*/
+
+/mob/living/carbon/proc/on_thermal_vision_gain()
+	ADD_TRAIT(src, TRAIT_THERMAL_VISION, TRAIT_GENERIC)
+	update_sight()
+
+/mob/living/carbon/proc/on_thermal_vision_loss()
+	REMOVE_TRAIT(src, TRAIT_THERMAL_VISION, TRAIT_GENERIC)
+	update_sight()
+
+/mob/living/carbon/proc/on_xray_vision_gain()
+	ADD_TRAIT(src, TRAIT_XRAY_VISION, TRAIT_GENERIC)
+	update_sight()
+
+/mob/living/carbon/proc/on_xray_vision_loss()
+	REMOVE_TRAIT(src, TRAIT_XRAY_VISION, TRAIT_GENERIC)
+	update_sight()
+
+/mob/living/carbon/proc/on_night_vision_gain()
+	ADD_TRAIT(src, TRAIT_NIGHT_VISION, TRAIT_GENERIC)
+	update_sight()
+
+/mob/living/carbon/proc/on_night_vision_loss()
+	REMOVE_TRAIT(src, TRAIT_NIGHT_VISION, TRAIT_GENERIC)
+	update_sight()

--- a/code/modules/vtmb/chi_disciplines.dm
+++ b/code/modules/vtmb/chi_disciplines.dm
@@ -1840,8 +1840,8 @@
 		if(1)
 			var/sound/auspexbeat = sound('code/modules/wod13/sounds/auspex.ogg', repeat = TRUE)
 			caster.playsound_local(caster, auspexbeat, 75, 0, channel = CHANNEL_DISCIPLINES, use_reverb = FALSE)
-			ADD_TRAIT(caster, TRAIT_NIGHT_VISION, TRAIT_GENERIC)
 			caster.add_client_colour(/datum/client_colour/glass_colour/lightblue)
+			ADD_TRAIT(caster, TRAIT_NIGHT_VISION, TRAIT_GENERIC)
 			var/datum/atom_hud/abductor_hud = GLOB.huds[DATA_HUD_ABDUCTOR]
 			abductor_hud.add_hud_to(caster)
 			caster.auspex_examine = TRUE
@@ -1852,8 +1852,8 @@
 					abductor_hud.remove_hud_from(caster)
 					caster.stop_sound_channel(CHANNEL_DISCIPLINES)
 					caster.playsound_local(caster.loc, 'code/modules/wod13/sounds/auspex_deactivate.ogg', 50, FALSE)
-					REMOVE_TRAIT(caster, TRAIT_NIGHT_VISION, TRAIT_GENERIC)
 					caster.remove_client_colour(/datum/client_colour/glass_colour/lightblue)
+					REMOVE_TRAIT(caster, TRAIT_NIGHT_VISION, TRAIT_GENERIC)
 		if(2)
 			var/sound/auspexbeat = sound('code/modules/wod13/sounds/auspex.ogg', repeat = TRUE)
 			caster.playsound_local(caster, auspexbeat, 75, 0, channel = CHANNEL_DISCIPLINES, use_reverb = FALSE)

--- a/code/modules/vtmb/chi_disciplines.dm
+++ b/code/modules/vtmb/chi_disciplines.dm
@@ -1841,7 +1841,6 @@
 			var/sound/auspexbeat = sound('code/modules/wod13/sounds/auspex.ogg', repeat = TRUE)
 			caster.playsound_local(caster, auspexbeat, 75, 0, channel = CHANNEL_DISCIPLINES, use_reverb = FALSE)
 			ADD_TRAIT(caster, TRAIT_NIGHT_VISION, TRAIT_GENERIC)
-			caster.update_sight()
 			caster.add_client_colour(/datum/client_colour/glass_colour/lightblue)
 			var/datum/atom_hud/abductor_hud = GLOB.huds[DATA_HUD_ABDUCTOR]
 			abductor_hud.add_hud_to(caster)
@@ -1855,13 +1854,11 @@
 					caster.playsound_local(caster.loc, 'code/modules/wod13/sounds/auspex_deactivate.ogg', 50, FALSE)
 					REMOVE_TRAIT(caster, TRAIT_NIGHT_VISION, TRAIT_GENERIC)
 					caster.remove_client_colour(/datum/client_colour/glass_colour/lightblue)
-					caster.update_sight()
 		if(2)
 			var/sound/auspexbeat = sound('code/modules/wod13/sounds/auspex.ogg', repeat = TRUE)
 			caster.playsound_local(caster, auspexbeat, 75, 0, channel = CHANNEL_DISCIPLINES, use_reverb = FALSE)
 			ADD_TRAIT(caster, TRAIT_THERMAL_VISION, TRAIT_GENERIC)
 			ADD_TRAIT(caster, TRAIT_NIGHT_VISION, TRAIT_GENERIC)
-			caster.update_sight()
 			var/datum/atom_hud/health_hud = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
 			health_hud.add_hud_to(caster)
 			caster.auspex_examine = TRUE
@@ -1874,7 +1871,6 @@
 					caster.playsound_local(caster.loc, 'code/modules/wod13/sounds/auspex_deactivate.ogg', 50, FALSE)
 					REMOVE_TRAIT(caster, TRAIT_THERMAL_VISION, TRAIT_GENERIC)
 					REMOVE_TRAIT(caster, TRAIT_NIGHT_VISION, TRAIT_GENERIC)
-					caster.update_sight()
 		if(3)
 			if(caster.lastattacked)
 				if(isliving(caster.lastattacked))

--- a/code/modules/vtmb/disciplines.dm
+++ b/code/modules/vtmb/disciplines.dm
@@ -398,7 +398,6 @@
 	if(!HAS_TRAIT(caster, TRAIT_NIGHT_VISION))
 		ADD_TRAIT(caster, TRAIT_NIGHT_VISION, TRAIT_GENERIC)
 		loh = TRUE
-	caster.update_sight()
 	caster.add_client_colour(/datum/client_colour/glass_colour/lightblue)
 	var/shitcasted = FALSE
 	if(level_casting >= 2)
@@ -429,7 +428,6 @@
 			if(loh)
 				REMOVE_TRAIT(caster, TRAIT_NIGHT_VISION, TRAIT_GENERIC)
 			caster.remove_client_colour(/datum/client_colour/glass_colour/lightblue)
-			caster.update_sight()
 
 /datum/discipline/celerity
 	name = "Celerity"

--- a/code/modules/vtmb/disciplines.dm
+++ b/code/modules/vtmb/disciplines.dm
@@ -393,12 +393,12 @@
 	. = ..()
 	var/sound/auspexbeat = sound('code/modules/wod13/sounds/auspex.ogg', repeat = TRUE)
 	caster.playsound_local(caster, auspexbeat, 75, 0, channel = CHANNEL_DISCIPLINES, use_reverb = FALSE)
+	caster.add_client_colour(/datum/client_colour/glass_colour/lightblue)
 	ADD_TRAIT(caster, TRAIT_THERMAL_VISION, TRAIT_GENERIC)
 	var/loh = FALSE
 	if(!HAS_TRAIT(caster, TRAIT_NIGHT_VISION))
 		ADD_TRAIT(caster, TRAIT_NIGHT_VISION, TRAIT_GENERIC)
 		loh = TRUE
-	caster.add_client_colour(/datum/client_colour/glass_colour/lightblue)
 	var/shitcasted = FALSE
 	if(level_casting >= 2)
 		var/datum/atom_hud/abductor_hud = GLOB.huds[DATA_HUD_ABDUCTOR]
@@ -424,10 +424,10 @@
 			health_hud.remove_hud_from(caster)
 			caster.stop_sound_channel(CHANNEL_DISCIPLINES)
 			caster.playsound_local(caster.loc, 'code/modules/wod13/sounds/auspex_deactivate.ogg', 50, FALSE)
+			caster.remove_client_colour(/datum/client_colour/glass_colour/lightblue)
 			REMOVE_TRAIT(caster, TRAIT_THERMAL_VISION, TRAIT_GENERIC)
 			if(loh)
 				REMOVE_TRAIT(caster, TRAIT_NIGHT_VISION, TRAIT_GENERIC)
-			caster.remove_client_colour(/datum/client_colour/glass_colour/lightblue)
 
 /datum/discipline/celerity
 	name = "Celerity"


### PR DESCRIPTION
## About The Pull Request

Ties `update_sight()` to the gaining/removal of sight-altering traits, rather than individual use-cases calling `update_sight()` whenever they assign or remove these traits (thermal, night vision, x-ray).

This fixes the gargoyle thermal vision from Visceratika 2+, it did not work unless something else called `update_sight()` on them.

Sadly, the signal for adding or removing traits don't handle sources, so I couldn't group these and turn it into a switch case.

Testing:

1. Activated Visceratika 2, noticed mobs immediately showing up. Waited. Mobs disappeared from sight when it was removed.
![image](https://github.com/user-attachments/assets/6b37a044-7d87-46fb-82ce-8f162d56667b)

2. Activated Feng Shui 1, noticed I can see mob. Waited. Mob begone.
![image](https://github.com/user-attachments/assets/190ef02d-8ac0-45e5-8cfe-af0b2986981f)

3. Activated Auspex 5, re-entered body, saw blue tint + auras for a little more, then they went away.
![image](https://github.com/user-attachments/assets/fdfd00c7-9362-4605-8239-32bddc0d9de2)


## Why It's Good For The Game

Bugs bad, fixes this report on Discord:

![image](https://github.com/user-attachments/assets/f46d79ee-3600-4beb-8c20-21c7a8ec060b)

## Changelog

fix: Fixes the thermal vision gained from Visceratika 2 and above to immediately work, now it turns on and off as it should.