### PR TITLE
Provides the Primogen with badges for Primogen Staff

### DIFF
--- a/code/modules/vtmb/jobs/jobs.dm
+++ b/code/modules/vtmb/jobs/jobs.dm
@@ -385,6 +385,43 @@
 
 //TZIMISCE ROLES
 
+// PRIMOGEN STAFF (They Distributed these In Game)
 
+/obj/item/card/id/whip
+	name = "primogen's whip badge"
+	id_type_name = "whip badge"
+	desc = "This badge shows your servitude to an important person."
+	icon = 'code/modules/wod13/items.dmi'
+	icon_state = "id2"
+	inhand_icon_state = "card-id"
+	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
+	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	worn_icon = 'code/modules/wod13/worn.dmi'
+	worn_icon_state = "id2"
 
+/obj/item/card/id/steward
+	name = "primogen's steward badge"
+	id_type_name = "steward badge"
+	desc = "This badge shows you're very good at taking care of someone else's property."
+	icon = 'code/modules/wod13/items.dmi'
+	icon_state = "id8"
+	inhand_icon_state = "card-id"
+	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
+	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	worn_icon = 'code/modules/wod13/worn.dmi'
+	worn_icon_state = "id8"
 
+/obj/item/card/id/myrmidon
+	name = "primogen's myrmidon badge"
+	id_type_name = "myrmidon badge"
+	desc = "A badge which shows you're responsible enough to protect someone important but not responsible enough to protect the most important."
+	icon = 'code/modules/wod13/items.dmi'
+	icon_state = "id4"
+	inhand_icon_state = "card-id"
+	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
+	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	worn_icon = 'code/modules/wod13/worn.dmi'
+	worn_icon_state = "id4"

--- a/code/modules/vtmb/jobs/primogen.dm
+++ b/code/modules/vtmb/jobs/primogen.dm
@@ -39,7 +39,7 @@
 	head = /obj/item/clothing/head/vampire/malkav
 	l_pocket = /obj/item/vamp/phone/malkavian
 	r_pocket = /obj/item/cockclock
-	backpack_contents = list(/obj/item/vamp/keys/malkav/primogen=1, /obj/item/vamp/keys/clinic, /obj/item/passport=1, /obj/item/flashlight=1, /obj/item/vamp/creditcard/elder=1)
+	backpack_contents = list(/obj/item/vamp/keys/malkav/primogen=1, /obj/item/vamp/keys/clinic, /obj/item/passport=1, /obj/item/flashlight=1, /obj/item/vamp/creditcard/elder=1, /obj/item/card/id/whip, /obj/item/card/id/steward, /obj/item/card/id/myrmidon)
 
 /datum/outfit/job/malkav/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -89,7 +89,7 @@
 	shoes = /obj/item/clothing/shoes/vampire
 	l_pocket = /obj/item/vamp/phone/nosferatu
 	r_pocket = /obj/item/cockclock
-	backpack_contents = list(/obj/item/vamp/keys/nosferatu/primogen=1, /obj/item/passport=1, /obj/item/flashlight=1, /obj/item/vamp/creditcard/elder=1)
+	backpack_contents = list(/obj/item/vamp/keys/nosferatu/primogen=1, /obj/item/passport=1, /obj/item/flashlight=1, /obj/item/vamp/creditcard/elder=1, /obj/item/card/id/whip, /obj/item/card/id/steward, /obj/item/card/id/myrmidon)
 
 /datum/outfit/job/nosferatu/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -135,7 +135,7 @@
 	shoes = /obj/item/clothing/shoes/vampire
 	l_pocket = /obj/item/vamp/phone/ventrue
 	r_pocket = /obj/item/cockclock
-	backpack_contents = list(/obj/item/vamp/keys/ventrue/primogen=1, /obj/item/passport=1, /obj/item/flashlight=1, /obj/item/vamp/creditcard/elder=1)
+	backpack_contents = list(/obj/item/vamp/keys/ventrue/primogen=1, /obj/item/passport=1, /obj/item/flashlight=1, /obj/item/vamp/creditcard/elder=1, /obj/item/card/id/whip, /obj/item/card/id/steward, /obj/item/card/id/myrmidon)
 
 /datum/outfit/job/ventrue/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -181,7 +181,7 @@
 	shoes = /obj/item/clothing/shoes/vampire
 	l_pocket = /obj/item/vamp/phone/toreador
 	r_pocket = /obj/item/cockclock
-	backpack_contents = list(/obj/item/vamp/keys/toreador/primogen=1, /obj/item/passport=1, /obj/item/flashlight=1, /obj/item/vamp/creditcard/elder=1)
+	backpack_contents = list(/obj/item/vamp/keys/toreador/primogen=1, /obj/item/passport=1, /obj/item/flashlight=1, /obj/item/vamp/creditcard/elder=1, /obj/item/card/id/whip, /obj/item/card/id/steward, /obj/item/card/id/myrmidon)
 
 /datum/outfit/job/toreador/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -229,4 +229,4 @@
 	shoes = /obj/item/clothing/shoes/vampire/jackboots
 	l_pocket = /obj/item/vamp/phone/brujah
 	r_pocket = /obj/item/cockclock
-	backpack_contents = list(/obj/item/vamp/keys/brujah/primogen=1, /obj/item/melee/vampirearms/eguitar=1, /obj/item/passport=1, /obj/item/flashlight=1, /obj/item/vamp/creditcard/elder=1)
+	backpack_contents = list(/obj/item/vamp/keys/brujah/primogen=1, /obj/item/melee/vampirearms/eguitar=1, /obj/item/passport=1, /obj/item/flashlight=1, /obj/item/vamp/creditcard/elder=1, /obj/item/card/id/whip, /obj/item/card/id/steward, /obj/item/card/id/myrmidon)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

In line with the Counsel of Primogen sourcebook for VtM, I have provided the Primogen with three badges in their backpack starting kit.

**Primogen's Myrmidon Badge**

A Myrmidon is the personal bodyguard of a Primogen, responsible for their safety and security, as well as breaking legs when needed.

**Primogen's Steward Badge**

A Steward is responsible for maintaining, stocking, and staffing the Primogen's domain/haven, hosting guests, etcetera.

**Primogen's Whip Badge**

A Whip is a Primogen's equivalent of a Seneschal, handling all of the personal affairs of the Primogen delegated to them, and often representing the Primogen at lesser functions.

## Why It's Good For The Game

The Primogen presently lack any structure to support maintaining a 'team' of confidants/staffers, which is extremely common for them to do in the lore. Despite this, Primogen players tend to be extremely active in game despite lacking the infrastructure individuals like the Prince / Capo / Regent have to support them via underlings.

These three badges will enable and encourage Primogen to hire/recruit other Kindred throughout the city to serve as their staff.

## Changelog

:cl:
add: Gave the Primogen three badges to distribute to their selected servants in line with official lore book.
:cl: