### PR TITLE
Baali can now infiltrate Camarilla/Anarchs/Chantry/Supply

### DIFF
--- a/code/modules/vtmb/jobs/anarchs/bouncer.dm
+++ b/code/modules/vtmb/jobs/anarchs/bouncer.dm
@@ -20,7 +20,7 @@
 
 	display_order = JOB_DISPLAY_ORDER_BRUISER
 	known_contacts = list("Baron")
-	allowed_bloodlines = list("Daughters of Cacophony", "True Brujah", "Brujah", "Nosferatu", "Gangrel", "Toreador", "Tremere", "Malkavian", "Banu Haqim", "Tzimisce", "Caitiff", "Ventrue", "Lasombra", "Gargoyle", "Kiasyd", "Cappadocian", "Ministry")
+	allowed_bloodlines = list("Daughters of Cacophony", "True Brujah", "Brujah", "Nosferatu", "Gangrel", "Toreador", "Tremere", "Malkavian", "Banu Haqim", "Tzimisce", "Caitiff", "Ventrue", "Lasombra", "Gargoyle", "Kiasyd", "Cappadocian", "Ministry", "Baali")
 
 	v_duty = "You are the enforcer of the Anarchs. The baron is always in need of muscle power. Enforce the Traditions - in the anarch way."
 	minimal_masquerade = 2

--- a/code/modules/vtmb/jobs/archivist.dm
+++ b/code/modules/vtmb/jobs/archivist.dm
@@ -21,7 +21,7 @@
 	v_duty = "Keep a census of events and provide information to neonates. Listen to the Regent Carefully. Study blood magic and protect the chantry."
 	minimal_masquerade = 3
 	allowed_species = list("Vampire")
-	allowed_bloodlines = list("Tremere", "Gargoyle")
+	allowed_bloodlines = list("Tremere", "Gargoyle", "Baali")
 	known_contacts = list("Tremere Regent")
 	experience_addition = 15
 

--- a/code/modules/vtmb/jobs/dealer.dm
+++ b/code/modules/vtmb/jobs/dealer.dm
@@ -25,7 +25,7 @@
 
 	my_contact_is_important = TRUE
 	known_contacts = list("Prince","Seneschal", "Sheriff", "Baron")
-	allowed_bloodlines = list("True Brujah", "Brujah", "Nosferatu", "Gangrel", "Toreador", "Malkavian", "Banu Haqim", "Tzimisce", "Caitiff", "Ventrue", "Ministry", "Kiasyd", "Cappadocian")
+	allowed_bloodlines = list("True Brujah", "Brujah", "Nosferatu", "Gangrel", "Toreador", "Malkavian", "Banu Haqim", "Tzimisce", "Caitiff", "Ventrue", "Ministry", "Kiasyd", "Cappadocian", "Baali")
 
 	v_duty = "You provide both legal and illegal supplies to those that get busy during the night. You are your own man yet you know people are out for you. Time to buckle in..."
 	minimal_masquerade = 3

--- a/code/modules/vtmb/jobs/scourge.dm
+++ b/code/modules/vtmb/jobs/scourge.dm
@@ -29,7 +29,7 @@
 	v_duty = "You are the Prince's enforcer. You report to the sheriff and uphold the Traditions."
 	minimal_masquerade = 4
 	experience_addition = 10
-	allowed_bloodlines = list("True Brujah", "Daughters of Cacophony", "Brujah", "Tremere", "Ventrue", "Nosferatu", "Gangrel", "Toreador", "Malkavian", "Banu Haqim", "Giovanni", "Ministry", "Lasombra", "Gargoyle", "Kiasyd", "Cappadocian")
+	allowed_bloodlines = list("True Brujah", "Daughters of Cacophony", "Brujah", "Tremere", "Ventrue", "Nosferatu", "Gangrel", "Toreador", "Malkavian", "Banu Haqim", "Giovanni", "Ministry", "Lasombra", "Gargoyle", "Kiasyd", "Cappadocian", "Baali")
 
 /datum/outfit/job/agent
 	name = "Scourge"

--- a/code/modules/vtmb/jobs/supply_assistant.dm
+++ b/code/modules/vtmb/jobs/supply_assistant.dm
@@ -19,7 +19,7 @@
 	bounty_types = CIV_JOB_RANDOM
 	allowed_species = list("Vampire", "Ghoul", "Human", "Kuei-Jin")
 	known_contacts = list("Dealer")
-	allowed_bloodlines = list("True Brujah", "Daughters of Cacophony", "Brujah", "Nosferatu", "Gangrel", "Toreador", "Malkavian", "Banu Haqim", "Tzimisce", "Caitiff", "Lasombra", "Gargoyle", "Kiasyd", "Cappadocian")
+	allowed_bloodlines = list("True Brujah", "Daughters of Cacophony", "Brujah", "Nosferatu", "Gangrel", "Toreador", "Malkavian", "Banu Haqim", "Tzimisce", "Caitiff", "Lasombra", "Gargoyle", "Kiasyd", "Cappadocian", "Baali")
 
 	v_duty = "You work for the Dealer, or are a part of their coterie. They pay well and the job is easy. Don't disappoint them."
 	duty = "Though your boss is odd and only works late night hours, they pay you well enough that you avoid questioning it."


### PR DESCRIPTION
## About The Pull Request

Baali can now infiltrate Camarilla/Anarchs/Chantry/Supply

## Why It's Good For The Game

That lets Baali actually be able to infiltrate different organizations like they could in the lore. Supply is independent/their own faction so Baali should be able to work here as well. Even Caitiff can become a dealer, so why not Baali? 

## Changelog

:cl:
add: Baali can join the round as Scourge, Bruiser, Chantry Archivist, Dealer, Supply Technician
/:cl:

