### PR TITLE
Gargoyle suits

### DIFF
--- a/code/modules/vtmb/vampire_clane/gargoyle.dm
+++ b/code/modules/vtmb/vampire_clane/gargoyle.dm
@@ -33,7 +33,6 @@
 
 /datum/vampireclane/gargoyle/on_gain(mob/living/carbon/human/H)
 	..()
-	H.dna.species.no_equip = list(ITEM_SLOT_OCLOTHING, ITEM_SLOT_SUITSTORE)
 	H.dna.species.wings_icon = "Gargoyle"
 	H.physiology.armor.melee += 20
 	H.physiology.armor.bullet += 20


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows gargoyles to wear things in the suit slot.

## Why It's Good For The Game

Their natural protection is outclassed by a $35 trenchcoat and really they should be able to wear most suits without too much trouble.

## Changelog

Gargoyles can wear suit slot items now. Certain suits such as robes will hide their wings in exchange for disallowing their flight.