### PR TITLE
Updates the ingame wiki link

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -210,7 +210,7 @@
 /datum/config_entry/string/banappeals
 
 /datum/config_entry/string/wikiurl
-	config_entry_value = "https://wod13.miraheze.org/wiki/"
+	config_entry_value = "https://wiki.wod13.org"
 
 /datum/config_entry/string/forumurl
 	config_entry_value = ""

--- a/config/config.txt
+++ b/config/config.txt
@@ -237,7 +237,7 @@ CHECK_RANDOMIZER
 FORUMURL https://discord.gg/WU92NG2Me8
 
 ## Wiki address
-WIKIURL https://discord.gg/WU92NG2Me8
+WIKIURL https://wiki.wod13.org
 
 ## Rules address
 RULESURL https://discord.gg/WU92NG2Me8

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -6,7 +6,7 @@
 	var/wikiurl = CONFIG_GET(string/wikiurl)
 	if(wikiurl)
 		if(query)
-			var/output = wikiurl + "/index.php?title=Special%3ASearch&profile=default&search=" + query
+			var/output = wikiurl + "/mediawiki/index.php?title=Special%3ASearch&search=" + query
 			src << link(output)
 		else if (query != null)
 			src << link(wikiurl)


### PR DESCRIPTION
## About The Pull Request

Our wiki was moved both domain- and engine-wise, so both the links and the search path had to be updated.

To test:
- Boot up the server
- Click "Wiki" on the top-right
  - Search for something, click Ok
  - Leave it empty, click Ok

## Why It's Good For The Game

The ingame wiki link does not point to the wrong wiki site.

## Changelog

:cl:
config: The ingame wiki link has been updated to point to the new wiki.
/:cl:
