### PR TITLE
Removes True Faith & Numina from Priests

### DIFF
--- a/code/modules/vtmb/jobs/priest.dm
+++ b/code/modules/vtmb/jobs/priest.dm
@@ -20,8 +20,7 @@
 	allowed_species = list("Human")
 	minimal_generation = 13
 
-	duty = "Be the shepherd of the flock in San Francisco, lead them to salvation, piety and righteousness."
-	v_duty = "The mortals believe you to be their savior. The kindred look at you with suspicion. Yours is the charge of this church."
+	duty = "Be the local spiritual leader of those within this district of San Francisco. You are old and have some basic education about theology."
 	minimal_masquerade = 0
 	my_contact_is_important = FALSE
 
@@ -37,33 +36,6 @@
 	l_hand = /obj/item/vamp/keys/church
 	back = /obj/item/storage/backpack/satchel
 	backpack_contents = list(/obj/item/passport=1, /obj/item/vamp/creditcard=1)
-
-/datum/outfit/job/priest/pre_equip(mob/living/carbon/human/H)
-	..()
-	add_verb(H, /datum/job/vampire/priest/verb/choose_special)
-
-/datum/job/vampire/priest/verb/choose_special()
-	set category = "Priest"
-	set name = "Choose Special"
-	set desc = "Select Priest special ability."
-	var/list/loadouts = list("Numina", "True Faith")
-	spawn()
-		var/mob/living/carbon/human/H = src
-		if(is_species(H, /datum/species/human))
-			if(H.client)
-				var/loadout_type = input(H, "Choose what makes you special:", "Loadout") as anything in loadouts
-				remove_verb(H, /datum/job/vampire/priest/verb/choose_special)
-				switch(loadout_type)
-					if("Numina")
-						to_chat(H, "<span class='alertsyndie'>You have been blessed with psychic powers. They make you extraordinary among mortals, yet you still fear the horrors lurking unknown.</span>")
-						var/obj/effect/proc_holder/spell/targeted/numina_freeze/n_freeze = new(H)
-						var/obj/effect/proc_holder/spell/self/numina_heal/n_heal = new(H)
-						H.mind.AddSpell(n_freeze)
-						H.mind.AddSpell(n_heal)
-					if("True Faith")
-						H.mind.holy_role = HOLY_ROLE_PRIEST
-						H.resistant_to_disciplines = TRUE
-						to_chat(H, "<span class='alertsyndie'>Your faith in God is made of iron. None could shake it, and even in the darkest moments it holds you up.</span>")
 
 /obj/effect/landmark/start/priest
 	name = "Priest"


### PR DESCRIPTION
## About The Pull Request

The following PR removes several tools Priests used to TDM exclusively, with RP being secondary to them. There have been several rounds where players have played a Priest screaming about "Heretics" and meta-targeting every "vampire" hideout because they are a Priest and must destroy "the unholy".

Before anyone says anything. Yes they are getting ahelped and no, there aren't enough staff to police it so a code implementation is being undertaken because everyone abused it. Yes, I've ahelped, its getting cracked down on.

## Why It's Good For The Game

Abilities should not be something you get for existing at round start; you should work for them (some, more than others i.e xp/money/etc), with that said, Priest has became reviled due to its /tg/ players treating the Priest role like they are Boris from terry.

Also another thing, true faith is supposed to be rare. Not everyone gets it, and neither should a role that anyone can be get it as people fundamentally don't understand the significance it has.

## Changelog
Removes numina/true faith from the priest.
Tweaks priest objectives.