### PR TITLE
reroll the roll code

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1020,6 +1020,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<b>See Runechat for non-mobs:</b> <a href='?_src_=prefs;preference=see_chat_non_mob'>[see_chat_non_mob ? "Enabled" : "Disabled"]</a><br>"
 			dat += "<b>See Runechat emotes:</b> <a href='?_src_=prefs;preference=see_rc_emotes'>[see_rc_emotes ? "Enabled" : "Disabled"]</a><br>"
 			dat += "<br>"
+			dat += "<b>Show Roll Results:</b> <a href='?_src_=prefs;preference=roll_mode'>[(chat_toggles & CHAT_ROLL_INFO) ? "All Rolls" : "Frenzy Only"]</a><br>"
+			dat += "<br>"
 			dat += "<b>Action Buttons:</b> <a href='?_src_=prefs;preference=action_buttons'>[(buttons_locked) ? "Locked In Place" : "Unlocked"]</a><br>"
 			dat += "<b>Hotkey mode:</b> <a href='?_src_=prefs;preference=hotkeys'>[(hotkeys) ? "Hotkeys" : "Default"]</a><br>"
 			dat += "<br>"
@@ -2874,6 +2876,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 				if("ghost_laws")
 					chat_toggles ^= CHAT_GHOSTLAWS
+
+				if("roll_mode")
+					chat_toggles ^= CHAT_ROLL_INFO
 
 				if("hear_login_logout")
 					chat_toggles ^= CHAT_LOGIN_LOGOUT

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -498,3 +498,13 @@ GLOBAL_LIST_INIT(ghost_orbits, list(GHOST_ORBIT_CIRCLE,GHOST_ORBIT_TRIANGLE,GHOS
 		return
 	prefs.asaycolor = initial(prefs.asaycolor)
 	prefs.save_preferences()
+
+
+/client/verb/toggle_roll_info()
+	set name = "Toggle Roll Info"
+	set category = "Preferences"
+	set desc = "See the results of in-game dice rolls."
+	usr.client.prefs.chat_toggles ^= CHAT_ROLL_INFO
+	to_chat(usr, "You will now [(usr.client.prefs.chat_toggles & CHAT_ROLL_INFO) ? "see the results of all rolls" : "only see the result of frenzy rolls"].")
+	usr.client.prefs.save_preferences()
+	SSblackbox.record_feedback("nested tally", "preferences_verb", 1, list("Show Roll Results", "[usr.client.prefs.chat_toggles & CHAT_ROLL_INFO ? "Yes" : "No"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/wod13/verbs/dice.dm
+++ b/code/modules/wod13/verbs/dice.dm
@@ -123,12 +123,12 @@
 	else
 		return trinary_result
 
-/mob/proc/roll_to_chat_list(var/list/viewers, var/input)
+/mob/proc/roll_to_chat_list(list/viewers, input)
 	for(var/mob/viewer in viewers)
 		if(viewer.client && viewer.client.prefs && viewer.client.prefs.chat_toggles & CHAT_ROLL_INFO)
 			to_chat(viewer, input)
 
-/mob/proc/get_dice_char(var/input)
+/mob/proc/get_dice_char(input)
 	switch(input)
 		if(1)
 			return "❶"

--- a/code/modules/wod13/verbs/dice.dm
+++ b/code/modules/wod13/verbs/dice.dm
@@ -16,6 +16,9 @@
  * * roll header:
  */
 /mob/proc/storyteller_roll(dice = 1, difficulty = 6, numerical = FALSE, roll_header="", show_player=TRUE, roll_viewers = list(src))
+	#ifdef DEBUG
+	show_player = TRUE
+	#endif
 
 	if(show_player)
 		. = storyteller_roll_pretty(dice, difficulty, numerical, roll_header, roll_viewers)

--- a/code/modules/wod13/verbs/dice.dm
+++ b/code/modules/wod13/verbs/dice.dm
@@ -13,6 +13,7 @@
  * * dice - number of 10-sided dice to roll.
  * * difficulty - the number that a dice must come up as to count as a success.
  * * numerical - whether the proc returns number of successes or outcome (botch, failure, success)
+ * * roll header:
  */
 /mob/proc/storyteller_roll(dice = 1, difficulty = 6, numerical = FALSE, roll_header="", show_player=TRUE, roll_viewers = list(src))
 	show_player = TRUE
@@ -60,12 +61,13 @@
 	var/had_success = FALSE
 	var/list/success_list = new()
 	var/list/fail_list = new()
+	var/roll_log = ""
 	if(roll_header && roll_header != "")
-		roll_to_chat_list(roll_viewers, "<h2>[roll_header]</h2>")
-	roll_to_chat_list(roll_viewers, "<h2>Difficulty: [difficulty]</h2>")
+		roll_log += "<h2>[roll_header]</h2><br>"
+	roll_log += "<h2>Difficulty: [difficulty]</h2><br>"
 
 	if (dice < 1)
-		roll_to_chat_list(roll_viewers, "<h2>Your Roll: <span style='color:DarkRed'>Auto Failure!</span></h2>")
+		roll_log += "<h2>Your Roll: <span style='color:DarkRed'>Auto Failure!</span></h2><br>"
 		if (numerical)
 			return 0
 		else
@@ -89,7 +91,7 @@
 			if (!had_success)
 				had_success = TRUE
 
-	var/roll_log = "<h2>Your Roll:"
+	roll_log += "<h2>Your Roll:"
 	if(success_list)
 		roll_log += "<span style='color:green'>"
 
@@ -123,7 +125,7 @@
 
 /mob/proc/roll_to_chat_list(var/list/viewers, var/input)
 	for(var/mob/viewer in viewers)
-		if(viewer.client.prefs.chat_toggles & CHAT_ROLL_INFO)
+		if(viewer.client && viewer.client.prefs && viewer.client.prefs.chat_toggles & CHAT_ROLL_INFO)
 			to_chat(viewer, input)
 
 /mob/proc/get_dice_char(var/input)

--- a/code/modules/wod13/verbs/dice.dm
+++ b/code/modules/wod13/verbs/dice.dm
@@ -16,7 +16,6 @@
  * * roll header:
  */
 /mob/proc/storyteller_roll(dice = 1, difficulty = 6, numerical = FALSE, roll_header="", show_player=TRUE, roll_viewers = list(src))
-	show_player = TRUE
 
 	if(show_player)
 		. = storyteller_roll_pretty(dice, difficulty, numerical, roll_header, roll_viewers)


### PR DESCRIPTION
## About The Pull Request

Improves the storyteller roll to have better big O complexity

Checks if people passed through roll_viewer are actually in possession of a client

Makes the preference option for toggling rolls exist; was deleted in a bad merge

## Why It's Good For The Game

uh, roll good, add rolls to all things pls, thx


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Readded the preferences toggle for storyteller rolls
qol: optimized the storyteller's roll code
fix: Fixed runtimes occurring when rolling against an NPC
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
