### PR TITLE
Speech bubble overlay no longer gets stuck on

### DIFF
--- a/code/modules/mob/living/carbon/carbon_say.dm
+++ b/code/modules/mob/living/carbon/carbon_say.dm
@@ -25,6 +25,8 @@
 		return initial(language.flags) & TONGUELESS_SPEECH
 
 /mob/living/carbon/input_say()
+	if(overlays_standing[SAY_LAYER])
+		return
 	var/mutable_appearance/say_overlay = mutable_appearance('icons/mob/talk.dmi', "default0", -SAY_LAYER)
 	overlays_standing[SAY_LAYER] = say_overlay
 	apply_overlay(SAY_LAYER)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
People were accidentally invoking the say verb twice, creating multiple overlays when the code is only capable of cutting the last one

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
Hi metek

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Speech bubble no longer gets stuck
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
