### PR TITLE
Orderable vitae packs in cargo

### DIFF
--- a/code/modules/wod13/cargo.dm
+++ b/code/modules/wod13/cargo.dm
@@ -38,6 +38,20 @@
 	contains = list(/obj/item/drinkable_bloodpack/elite, /obj/item/drinkable_bloodpack/elite, /obj/item/drinkable_bloodpack/elite, /obj/item/drinkable_bloodpack/elite, /obj/item/drinkable_bloodpack/elite)
 	crate_name = "blood crate"
 
+/datum/supply_pack/vampire/vitaepack
+	name = "Vitae Pack"
+	desc = "Contains 5 vitae packs."
+	cost = 100
+	contains = list(/obj/item/drinkable_bloodpack/vitae, /obj/item/drinkable_bloodpack/vitae, /obj/item/drinkable_bloodpack/vitae, /obj/item/drinkable_bloodpack/vitae, /obj/item/drinkable_bloodpack/vitae)
+	crate_name = "vitae crate"
+
+/datum/supply_pack/vampire/vitaepack_elder
+	name = "Elder Vitae Pack"
+	desc = "Contains 5 elder vitae packs."
+	cost = 300
+	contains = list(/obj/item/drinkable_bloodpack/vitae/elder, /obj/item/drinkable_bloodpack/vitae/elder, /obj/item/drinkable_bloodpack/vitae/elder, /obj/item/drinkable_bloodpack/vitae/elder, /obj/item/drinkable_bloodpack/vitae/elder)
+	crate_name = "vitae crate"
+
 /datum/supply_pack/vampire/weaponstake
 	name = "Weapon (stake)"
 	desc = "Contains 3 usable wooden stakes."

--- a/code/modules/wod13/special_shit.dm
+++ b/code/modules/wod13/special_shit.dm
@@ -141,6 +141,11 @@
 	amount_of_bloodpoints = 4
 	vitae = TRUE
 
+/obj/item/drinkable_bloodpack/vitae/elder
+	name = "\improper elder vitae pack (full)"
+	amount_of_bloodpoints = 8
+
+
 /obj/item/blood_hunt
 	name = "Blood Hunt Announcer"
 	desc = "Announce a Blood Hunt to the city."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://github.com/user-attachments/assets/c5d981d2-01a5-440c-a4bb-1a9569900423)
vitae packs can now be ordered in cargo, same way and price as blood packs

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

previously, the only way to get vitae packs was to get it thru several places they are MAPPED IN
and when they were out, you couldnt get more

now you can buy them, similar to blood packs
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: added elder blood pack subtype because people were mapping them in previously
add: elder vitae pack in cargo
add: vitae pack in cargo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
