### PR TITLE
Bloodpacks can no longer be ordered from cargo, and can no longer be generated from NPCs or disconnected player

### DIFF
--- a/code/modules/wod13/cargo.dm
+++ b/code/modules/wod13/cargo.dm
@@ -24,20 +24,6 @@
 	contains = list(/obj/item/wire_cutters, /obj/item/storage/box/lights/mixed)
 	crate_name = "weapon crate"
 
-/datum/supply_pack/vampire/bloodpack
-	name = "Blood Pack"
-	desc = "Contains 5 default blood packs."
-	cost = 100
-	contains = list(/obj/item/drinkable_bloodpack, /obj/item/drinkable_bloodpack, /obj/item/drinkable_bloodpack, /obj/item/drinkable_bloodpack, /obj/item/drinkable_bloodpack)
-	crate_name = "blood crate"
-
-/datum/supply_pack/vampire/bloodpack_elite
-	name = "Elite Blood Pack"
-	desc = "Contains 5 elite blood packs."
-	cost = 300
-	contains = list(/obj/item/drinkable_bloodpack/elite, /obj/item/drinkable_bloodpack/elite, /obj/item/drinkable_bloodpack/elite, /obj/item/drinkable_bloodpack/elite, /obj/item/drinkable_bloodpack/elite)
-	crate_name = "blood crate"
-
 /datum/supply_pack/vampire/weaponstake
 	name = "Weapon (stake)"
 	desc = "Contains 3 usable wooden stakes."

--- a/code/modules/wod13/decor.dm
+++ b/code/modules/wod13/decor.dm
@@ -747,12 +747,14 @@
 /mob/living/carbon/human/MouseDrop(atom/over_object)
 	. = ..()
 	if(istype(over_object, /obj/structure/bloodextractor))
+		var/obj/structure/bloodextractor/V = over_object
 		if(isnull(src.mind) || !src.mind.active)
-			src.visible_message("<span class='warning'>[src] struggles too much to be hooked to [V], resisting instinctively!\
-			One would thi_N_k _P_erhaps they _C_an't be tapped for blood with that much willful resistance...")
+			visible_message("<span class='warning'>[src] struggles too much to be hooked to [V]!</span>")
+			// Painful to use usr here but we don't have infrastructure for passing in the caller mob
+			if(ismob(usr) && usr.mind)
+				to_chat(usr, "This machine can only be used on active players.")
 			return
 		if(get_dist(src, over_object) < 2)
-			var/obj/structure/bloodextractor/V = over_object
 			if(!buckled)
 				V.visible_message("<span class='warning'>Buckle [src] fist!</span>")
 			if(bloodpool < 2)

--- a/code/modules/wod13/decor.dm
+++ b/code/modules/wod13/decor.dm
@@ -747,6 +747,9 @@
 /mob/living/carbon/human/MouseDrop(atom/over_object)
 	. = ..()
 	if(istype(over_object, /obj/structure/bloodextractor))
+		if(isnull(src.mind) || !src.mind.active)
+			src.visible_message("<span class='warning'>[src] struggles too much to be hooked to [V], resisting instinctively!\
+			One would thi_N_k _P_erhaps they _C_an't be tapped for blood with that much willful resistance...")
 		if(get_dist(src, over_object) < 2)
 			var/obj/structure/bloodextractor/V = over_object
 			if(!buckled)

--- a/code/modules/wod13/decor.dm
+++ b/code/modules/wod13/decor.dm
@@ -750,6 +750,7 @@
 		if(isnull(src.mind) || !src.mind.active)
 			src.visible_message("<span class='warning'>[src] struggles too much to be hooked to [V], resisting instinctively!\
 			One would thi_N_k _P_erhaps they _C_an't be tapped for blood with that much willful resistance...")
+			return
 		if(get_dist(src, over_object) < 2)
 			var/obj/structure/bloodextractor/V = over_object
 			if(!buckled)

--- a/code/modules/wod13/postal.dm
+++ b/code/modules/wod13/postal.dm
@@ -78,7 +78,6 @@
 						/obj/item/stack/dollar/rand,
 						/obj/item/melee/vampirearms/knife,
 						/obj/item/melee/vampirearms/tire,
-						/datum/supply_pack/vampire/bloodpack,
 						/obj/item/gun/ballistic/vampire/revolver,
 						/obj/item/vamp/keys/hack)
 		new IT(user.loc)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The title explains the entirety of what this pull request does.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

From my observing, NPCs are treated as mindless bloodpack factories rather than players making an attempt to treat them as if they're human being who are part of the world. This is an immense negative to immersion. Additionally, these infinite bloodpack factories totally destroy the dynamic of vampires needing to feed on the blood of the living to survive; instead, everyone is just carrying around mana potions instead of actually hunting humans for blood.

This change will make it so that bloodpacks can only be (for now) gained from players who consent or are otherwise coerced into donating blood at the machines. Right now the machines don't actually do anything to your real blood volume; it simply lowers your bloodpool (which, incidentally for humans, is actually totally separate from your body's blood volume and seemingly doesn't interact with it at all...). That will change in the future but for now, to get your mana potions, you need to get them from a player, and I don't mean over the counter.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Bisar
balance: Bloodpacks can now only be created from players with active minds; they cannot be gained from NPCs, disconnected players, or ordered from cargo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
