### PR TITLE
Fixes the Police Chief's door being invisible

### DIFF
--- a/_maps/map_files/Vampire/SanFrancisco.dmm
+++ b/_maps/map_files/Vampire/SanFrancisco.dmm
@@ -5476,7 +5476,7 @@
 "fVf" = (/obj/structure/vampdoor/camarilla{lockpick_difficulty = 9},/turf/open/floor/plating/vampplating/mono,/area/vtm/interior/millennium_tower)
 "fVm" = (/obj/structure/filingcabinet/chestdrawer/wheeled,/turf/open/floor/plating/parquetry/old,/area/vtm/interior/police)
 "fVI" = (/obj/structure/railing{dir = 8},/obj/structure/table,/obj/item/megaphone,/obj/structure/coclock,/turf/open/floor/plating/rough,/area/vtm/interior)
-"fVX" = (/obj/effect/decal/rugs,/obj/structure/vampdoor/glass/police_chief{lockpick_difficulty = 23},/turf/open/floor/plating/parquetry/old,/area/vtm/interior/police)
+"fVX" = (/obj/effect/decal/rugs,/obj/structure/vampdoor/glass/police_chief,/turf/open/floor/plating/parquetry/old,/area/vtm/interior/police)
 "fWo" = (/obj/structure/table/wood,/obj/structure/reagent_dispensers/beerkeg,/turf/open/floor/plating/parquetry/old,/area/vtm/jazzclub)
 "fWr" = (/obj/machinery/light/small{dir = 4; pixel_x = -16},/obj/structure/chair/comfy/black,/turf/open/floor/plating/parquetry/old,/area/vtm/graveyard/interior)
 "fWz" = (/obj/structure/rack,/turf/open/floor/plating/vampplating,/area/vtm/interior/techshop)

--- a/_maps/map_files/Vampire/SanFrancisco.dmm
+++ b/_maps/map_files/Vampire/SanFrancisco.dmm
@@ -5476,7 +5476,7 @@
 "fVf" = (/obj/structure/vampdoor/camarilla{lockpick_difficulty = 9},/turf/open/floor/plating/vampplating/mono,/area/vtm/interior/millennium_tower)
 "fVm" = (/obj/structure/filingcabinet/chestdrawer/wheeled,/turf/open/floor/plating/parquetry/old,/area/vtm/interior/police)
 "fVI" = (/obj/structure/railing{dir = 8},/obj/structure/table,/obj/item/megaphone,/obj/structure/coclock,/turf/open/floor/plating/rough,/area/vtm/interior)
-"fVX" = (/obj/effect/decal/rugs,/obj/structure/vampdoor/police/chief{lockpick_difficulty = 23},/turf/open/floor/plating/parquetry/old,/area/vtm/interior/police)
+"fVX" = (/obj/effect/decal/rugs,/obj/structure/vampdoor/glass/police_chief{lockpick_difficulty = 23},/turf/open/floor/plating/parquetry/old,/area/vtm/interior/police)
 "fWo" = (/obj/structure/table/wood,/obj/structure/reagent_dispensers/beerkeg,/turf/open/floor/plating/parquetry/old,/area/vtm/jazzclub)
 "fWr" = (/obj/machinery/light/small{dir = 4; pixel_x = -16},/obj/structure/chair/comfy/black,/turf/open/floor/plating/parquetry/old,/area/vtm/graveyard/interior)
 "fWz" = (/obj/structure/rack,/turf/open/floor/plating/vampplating,/area/vtm/interior/techshop)

--- a/_maps/map_files/Vampire/runtimetown.dmm
+++ b/_maps/map_files/Vampire/runtimetown.dmm
@@ -137,7 +137,7 @@
 "BX" = (/obj/structure/table,/turf/closed/wall/vampwall/market/low,/area/vtm/interior/shop)
 "Ca" = (/obj/structure/table,/obj/item/gun/ballistic/automatic/vampire/sniper,/turf/open/floor/plating/rough,/area/vtm/pacificheights)
 "Cg" = (/obj/structure/table/wood,/obj/machinery/mineral/equipment_vendor/fastfood/library,/turf/closed/wall/vampwall/painted/low,/area/vtm/interior/shop)
-"Cr" = (/obj/structure/vampdoor/police/chief,/turf/open/floor/plating/toilet,/area/vtm/interior/shop)
+"Cr" = (/obj/structure/vampdoor/glass/police_chief,/turf/open/floor/plating/toilet,/area/vtm/interior/shop)
 "Cz" = (/obj/effect/decal/asphaltline{dir = 8},/obj/structure/roadblock{dir = 8},/turf/open/floor/plating/asphalt,/area/vtm/pacificheights)
 "Db" = (/obj/machinery/light{dir = 8},/turf/open/floor/plating/vampdirt,/area/vtm/supply)
 "Df" = (/obj/structure/closet/crate/freezer/blood{name = "vampire blood freezer"},/obj/item/drinkable_bloodpack/vitae,/obj/item/drinkable_bloodpack/vitae,/obj/item/drinkable_bloodpack/vitae,/obj/item/drinkable_bloodpack/vitae,/obj/item/drinkable_bloodpack/vitae,/obj/item/drinkable_bloodpack/vitae,/turf/open/floor/plating/rough,/area/vtm/pacificheights)

--- a/code/modules/wod13/doorcode.dm
+++ b/code/modules/wod13/doorcode.dm
@@ -667,6 +667,11 @@
 	lock_id = "primToreador"
 	lockpick_difficulty = 14
 
+/obj/structure/vampdoor/glass/police_chief
+	locked = TRUE
+	lock_id = "police_chief"
+	lockpick_difficulty = 21
+
 /obj/structure/vampdoor/camarilla
 	icon_state = "cam-1"
 	baseicon = "cam"
@@ -760,15 +765,6 @@
 	baseicon = "cam"
 	locked = TRUE
 	lock_id = "police_secure"
-	lockpick_difficulty = 21
-
-/obj/structure/vampdoor/police/chief
-	icon_state = "shop-1"
-	opacity = FALSE
-	locked = TRUE
-	baseicon = "shop"
-	glass = TRUE
-	lock_id = "police_chief"
 	lockpick_difficulty = 21
 
 /obj/structure/vampdoor/prison


### PR DESCRIPTION
## About The Pull Request

Fixes the police chief door being invisible as it was not a glass door subtype.

https://github.com/user-attachments/assets/ccb85e1a-5ef0-424f-a0b1-514845e89be4

## Why It's Good For The Game

It is visible now.

## Changelog

Fixes the Police Chief's door being invisible.