### PR TITLE
make the voice of god aka dominate take up less of your chat

### DIFF
--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -564,6 +564,7 @@ em {
 .narsie {
   color: #973e3b;
   font-weight: bold;
+  font-size: 925%;
 }
 
 .narsiesmall {

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -393,7 +393,6 @@ em {
 .userdanger {
   color: #c51e1e;
   font-weight: bold;
-  font-size: 185%;
 }
 
 .userhelp {

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -563,18 +563,15 @@ em {
 .narsie {
   color: #973e3b;
   font-weight: bold;
-  font-size: 925%;
 }
 
 .narsiesmall {
   color: #973e3b;
   font-weight: bold;
-  font-size: 370%;
 }
 
 .colossus {
   color: #7F282A;
-  font-size: 310%;
 }
 
 .hierophant {

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -393,6 +393,7 @@ em {
 .userdanger {
   color: #c51e1e;
   font-weight: bold;
+  font-size: 185%;
 }
 
 .userhelp {

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -604,6 +604,7 @@ h1.alert, h2.alert {
 .narsie {
   color: #973e3b;
   font-weight: bold;
+  font-size: 925%;
 }
 
 .narsiesmall {

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -418,6 +418,7 @@ h1.alert, h2.alert {
 .userdanger {
   color: #ff0000;
   font-weight: bold;
+  font-size: 185%;
 }
 
 .userhelp {

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -418,7 +418,6 @@ h1.alert, h2.alert {
 .userdanger {
   color: #ff0000;
   font-weight: bold;
-  font-size: 185%;
 }
 
 .userhelp {
@@ -604,18 +603,15 @@ h1.alert, h2.alert {
 .narsie {
   color: #973e3b;
   font-weight: bold;
-  font-size: 925%;
 }
 
 .narsiesmall {
   color: #973e3b;
   font-weight: bold;
-  font-size: 370%;
 }
 
 .colossus {
   color: #7F282A;
-  font-size: 310%;
 }
 
 .hierophant {


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

simple webedit that should stop the voice of god taking up the entire screen

## Why It's Good For The Game

maybe the voice of god shouldn't be gigantic

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: changed the dominate discipline font size
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
