### PR TITLE
Fix flavor text exploit

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2377,7 +2377,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						lover_text = trim(copytext_char(sanitize(new_text), 1, 512))
 
 				if("flavor_text")
-					var/new_flavor = input(user, "Choose your character's flavor text:", "Character Preference")  as text|null
+					var/new_flavor = input(user, "Choose your character's flavor text:", "Character Preference") as text|null
 					if(new_flavor)
 						flavor_text = trim(copytext_char(sanitize(new_flavor), 1, 512))
 

--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -15,26 +15,6 @@
 		return
 	say(message)
 
-/mob/living/verb/flavor_verb()
-	set name = "Flavor Text"
-	set category = "IC"
-	var/flavor = input("Choose your new flavor text:") as text|null
-	if(flavor)
-		var/pattern = "<img"
-		var/pos = findtext(flavor, pattern)
-		if(pos)
-			to_chat(src, "Embedding images is not allowed.")
-			return
-		pattern = "<picture"
-		pos = findtext(flavor, pattern)
-		if(pos)
-			to_chat(src, "Embedding images is not allowed.")
-			return
-		if(length(flavor) > 3 * 512)
-			to_chat(src, "Too long...")
-		else
-			flavor_text = sanitize_text(flavor)
-
 ///Whisper verb
 /mob/verb/whisper_verb(message as text)
 	set name = "Whisper"

--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -15,6 +15,13 @@
 		return
 	say(message)
 
+/mob/living/verb/flavor_verb()
+	set name = "Flavor Text"
+	set category = "IC"
+	var/flavor = input("Choose your new flavor text:") as text|null
+	if(flavor)
+		flavor_text = trim(copytext_char(sanitize(flavor), 1, 512))
+
 ///Whisper verb
 /mob/verb/whisper_verb(message as text)
 	set name = "Whisper"


### PR DESCRIPTION
## About The Pull Request
So, funny thing. Besides setting your flavor text in your character setup menu, there was for some reason a copy pasted verb that let you do the same thing but without any HTML stripping. This led to people putting images and videos in their flavor text.

## Why It's Good For The Game
No more HTML injection and possible bad stuff.

## Changelog
:cl:
fix: Removed flavor text verb.
/:cl:
