### PR TITLE
Adds a typing indicator to the me command, small say refactor, crinos speech bubble

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -69,7 +69,7 @@
 	return copytext((html_encode(strip_html_simple(t))),1,limit)
 
 /proc/message_clean(message)
-	return trim(copytext_char(sanitize(message), 1, MAX_BROADCAST_LEN))
+	return copytext_char(sanitize(message), 1, MAX_BROADCAST_LEN)
 
 /**
  * Perform a whitespace cleanup on the text, similar to what HTML renderers do

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -68,6 +68,9 @@
 /proc/adminscrub(t,limit=MAX_MESSAGE_LEN)
 	return copytext((html_encode(strip_html_simple(t))),1,limit)
 
+/proc/message_clean(message)
+	return trim(copytext_char(sanitize(message), 1, MAX_BROADCAST_LEN))
+
 /**
  * Perform a whitespace cleanup on the text, similar to what HTML renderers do
  *

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -69,7 +69,7 @@
 	return copytext((html_encode(strip_html_simple(t))),1,limit)
 
 /proc/message_clean(message)
-	return copytext_char(sanitize(message), 1, MAX_BROADCAST_LEN)
+	return copytext(sanitize(message), 1, MAX_BROADCAST_LEN)
 
 /**
  * Perform a whitespace cleanup on the text, similar to what HTML renderers do

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -149,6 +149,8 @@
 	///AI controller that controls this atom. type on init, then turned into an instance during runtime
 	var/datum/ai_controller/ai_controller
 
+	///What icon the atom uses for speech bubbles
+	var/bubble_icon = "default"
 /**
  * Called when an atom is created in byond (built in engine proc)
  *

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -959,7 +959,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 				if("South")
 					movement_keys[key] = SOUTH
 				if("Say")
-					winset(src, "default-[REF(key)]", "parent=default;name=[key];command=inputSay")
+					winset(src, "default-[REF(key)]", "parent=default;name=[key];command=say")
 				if("OOC")
 					winset(src, "default-[REF(key)]", "parent=default;name=[key];command=ooc")
 				if("Me")

--- a/code/modules/mob/living/carbon/carbon_say.dm
+++ b/code/modules/mob/living/carbon/carbon_say.dm
@@ -23,15 +23,3 @@
 		return T.could_speak_language(language)
 	else
 		return initial(language.flags) & TONGUELESS_SPEECH
-
-/mob/living/carbon/input_say()
-	if(overlays_standing[SAY_LAYER])
-		return
-	var/mutable_appearance/say_overlay = mutable_appearance('icons/mob/talk.dmi', "default0", -SAY_LAYER)
-	overlays_standing[SAY_LAYER] = say_overlay
-	apply_overlay(SAY_LAYER)
-	..()
-
-/mob/living/carbon/say_verb(message as text|null)
-	remove_overlay(SAY_LAYER)
-	..()

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -1,4 +1,5 @@
 /mob/living/carbon/death(gibbed)
+	set_typing_indicator(FALSE)
 	if(stat == DEAD)
 		return
 

--- a/code/modules/mob/living/carbon/werewolf/life.dm
+++ b/code/modules/mob/living/carbon/werewolf/life.dm
@@ -1,4 +1,5 @@
 /mob/living/carbon/werewolf/Life()
+	update_icons()
 	update_rage_hud()
 	return..()
 

--- a/code/modules/mob/living/carbon/werewolf/life.dm
+++ b/code/modules/mob/living/carbon/werewolf/life.dm
@@ -1,5 +1,4 @@
 /mob/living/carbon/werewolf/Life()
-	update_icons()
 	update_rage_hud()
 	return..()
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1754,6 +1754,7 @@
 			REMOVE_TRAIT(src, TRAIT_INCAPACITATED, STAT_TRAIT)
 			REMOVE_TRAIT(src, TRAIT_FLOORED, STAT_TRAIT)
 			REMOVE_TRAIT(src, TRAIT_CRITICAL_CONDITION, STAT_TRAIT)
+			set_typing_indicator(FALSE)
 		if(SOFT_CRIT)
 			if(pulledby)
 				ADD_TRAIT(src, TRAIT_IMMOBILIZED, PULLED_WHILE_SOFTCRIT_TRAIT) //adding trait sources should come before removing to avoid unnecessary updates

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -104,7 +104,6 @@
 
 	var/smoke_delay = 0 ///used to prevent spam with smoke reagent reaction on mob.
 
-	var/bubble_icon = "default" ///what icon the mob uses for speechbubbles
 	var/health_doll_icon ///if this exists AND the normal sprite is bigger than 32x32, this is the replacement icon state (because health doll size limitations). the icon will always be screen_gen.dmi
 
 	var/last_bumped = 0

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -367,14 +367,19 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 			AM.Hear(rendered, src, message_language, message, , spans, message_mods)
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_LIVING_SAY_SPECIAL, src, message)
 
-	//speech bubble
+	// A speech bubble icon flicks at the end of the speech, based on the last character
+	var/message_ending = copytext_char(message, -1)
+	var/custom_speech_bubble_ending = "0"
+	if(message_ending == "?")
+		custom_speech_bubble_ending = "1"
+	if(message_ending == "!")
+		custom_speech_bubble_ending = "2"
+
 	var/list/speech_bubble_recipients = list()
 	for(var/mob/M in listening)
-		if(M.client && !M.client.prefs.chat_on_map)
+		if(M.client)
 			speech_bubble_recipients.Add(M.client)
-	var/image/I = image('icons/mob/talk.dmi', src, "[bubble_type][say_test(message)]", FLY_LAYER)
-	I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
-	INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(flick_overlay), I, speech_bubble_recipients, 30)
+	speech_ending_bubble("[bubble_icon][custom_speech_bubble_ending]", src, speech_bubble_recipients)
 
 /mob/proc/binarycheck()
 	return FALSE

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -114,7 +114,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 		ic_blocked = TRUE
 
 	if(sanitize)
-		message = trim(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN))
+		message = trim(copytext_char(sanitize(message), 1, MAX_BROADCAST_LEN))
 	if(!message || message == "")
 		return FALSE
 

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -1,4 +1,5 @@
 /mob/Logout()
+	set_typing_indicator(FALSE)
 	SEND_SIGNAL(src, COMSIG_MOB_LOGOUT)
 	log_message("[key_name(src)] is no longer owning mob [src]([src.type])", LOG_OWNERSHIP)
 	SStgui.on_logout(src)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -240,3 +240,6 @@
 
 	//imported variables from all around the code
 	var/taxist = FALSE
+
+	///Is the mob currently typing?
+	var/typing = FALSE

--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -55,9 +55,9 @@ GLOBAL_LIST_EMPTY(typing_indicator)
 		to_chat(usr, "<span class='danger'>Speech is currently admin-disabled.</span>")
 		return
 
-	set_typing_indicator(TRUE)
+	set_typing_indicator(TRUE, TRUE)
 	var/message = input("What are you trying to emote? (A maximum of [MAX_BROADCAST_LEN] characters])") as text|null
-	set_typing_indicator(FALSE)
+	set_typing_indicator(FALSE, TRUE)
 
 	if(!message)
 		return

--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -18,7 +18,6 @@ GLOBAL_LIST_EMPTY(typing_indicator)
 
 	if(!message)
 		return
-	message = message_clean(message)
 
 	say(message)
 
@@ -38,7 +37,6 @@ GLOBAL_LIST_EMPTY(typing_indicator)
 
 	if(!message)
 		return
-	message = message_clean(message)
 
 	whisper(message)
 

--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -13,10 +13,10 @@ GLOBAL_LIST_EMPTY(typing_indicator)
 		return
 
 	set_typing_indicator(TRUE)
-	var/message = input("What are you trying to say? (A maximum of [MAX_BROADCAST_LEN] characters]") as text|null
+	var/message = input("What are you trying to say?") as text|null
 	set_typing_indicator(FALSE)
 
-	if(!message)
+	if(!message || message_max_length_check(message))
 		return
 
 	say(message)
@@ -32,10 +32,10 @@ GLOBAL_LIST_EMPTY(typing_indicator)
 		return
 
 	set_typing_indicator(TRUE)
-	var/message = input("What are you trying to whisper? (A maximum of [MAX_BROADCAST_LEN] characters]") as text|null
+	var/message = input("What are you trying to whisper?") as text|null
 	set_typing_indicator(FALSE)
 
-	if(!message)
+	if(!message || message_max_length_check(message))
 		return
 
 	whisper(message)
@@ -54,14 +54,19 @@ GLOBAL_LIST_EMPTY(typing_indicator)
 		return
 
 	set_typing_indicator(TRUE, TRUE)
-	var/message = input("What are you trying to emote? (A maximum of [MAX_BROADCAST_LEN] characters])") as text|null
+	var/message = input("What are you trying to emote?") as text|null
 	set_typing_indicator(FALSE, TRUE)
 
-	if(!message)
+	if(!message || message_max_length_check(message))
 		return
 	message = message_clean(message)
 
 	usr.emote("me", 1, message, TRUE)
+
+/mob/proc/message_max_length_check(message)
+	if(length(message) > MAX_BROADCAST_LEN && client)
+		to_chat(src, span_warning("Your message was too long to be sent. The message:<br>[message]"))
+		return TRUE
 
 /mob/living/verb/flavor_verb()
 	set name = "Flavor Text"

--- a/code/modules/vtmb/disciplines.dm
+++ b/code/modules/vtmb/disciplines.dm
@@ -1887,7 +1887,7 @@
 					if ((victim.wear_mask?.flags_inv & HIDEFACE) || (victim.head?.flags_inv & HIDEFACE))
 						masked = TRUE
 						base_difficulty += 2
-					if (victim.overlays_standing[SAY_LAYER]) //ugly way to check for if the victim is currently typing
+					if (victim.typing)
 						base_difficulty += 2
 
 				for (var/mob/living/hearer in (view(7, target) - caster - target))


### PR DESCRIPTION
## About The Pull Request

Updated our say command a little, here are the changes:
- Added the speech bubble to the me and whisper commands
- Added a line ending (...), (!) or (?) bubble that lingers for 2 seconds after you sent a verbal message, depending on the last character of the message
- Refactored how the typing indicator works
- Added a limitation of 512 characters to the say, me, and whisper commands
- Added a custom bubble for the Crinos form, if the Garou players like this, we can have one for the Glabro and Lupus forms as well (we just need sprites, it's a one-line code change)
- Removed the input_say() verb, it was pointless

NPCs currently do not use this system.

## Why It's Good For The Game

We are supposedly a roleplay server, so small features like this help with immersion. Now you can see if someone is writing a lengthy emote.

This can be later expanded to `atom_say()` that I also intend to port over.

The only concern I have that I might have missed a case where the bubble lingers, but that might be a trial & error thing to find.

## Changelog

- Added the speech bubble to the me and whisper commands.
- Added a line ending (...), (!) or (?) bubble that lingers for 2 seconds after you sent a verbal message, depending on the last character of the message.
- Added a limitation of 512 characters to the say, me, and whisper commands.