### PR TITLE
Fixes BSD Totem Portal Marker

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -211,7 +211,7 @@
 "Ce" = (/obj/effect/decal/graffiti/large,/turf/open/floor/plating/umbra,/area/vtm/interior/penumbra)
 "Cg" = (/obj/structure/chair/sofa/corp/corner{dir = 4; icon_state = "corp_sofacorner"},/turf/open/floor/plating/concrete,/area/vtm/interior/penumbra)
 "Ck" = (/turf/open/floor/plating/concrete,/area/vtm/interior/penumbra)
-"Cp" = (/obj/effect/landmark/teleport_mark{tribe = "Black Spiral"},/turf/open/indestructible/necropolis/air{umbra = 1},/area/vtm/interior/penumbra)
+"Cp" = (/obj/effect/landmark/teleport_mark{tribe = "Black Spiral Dancers"},/turf/open/indestructible/necropolis/air{umbra = 1},/area/vtm/interior/penumbra)
 "Cr" = (/obj/structure/chair/sofa/corp/left,/turf/open/floor/plating/concrete,/area/vtm/interior/penumbra)
 "Ct" = (/obj/transfer_point_vamp/umbral{id = 661},/turf/open/floor/plating/asphalt{umbra = 1},/area/vtm/interior/penumbra)
 "Cw" = (/obj/item/stack/dollar/hundred{amount = 1000; anchored = 1},/obj/effect/decal/litter,/turf/open/floor/plating/umbra,/area/vtm/interior/penumbra)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the lack of a properly var'd teleport marker in the Umbra causing BSD Theurges to be unable to reach the Umbra.


https://github.com/user-attachments/assets/6d73b0bd-acb0-4acd-8816-853e0dfa8fe4


## Why It's Good For The Game

Let's BSD Theurges do what they should be able to. Prevents BSDs from having to awkwardly use other totems.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Adjusts the teleport marker's Tribe Var for the BSD's to properly reference their Tribe name.
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
