### PR TITLE
Removes blushing from Charmer

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -14,16 +14,6 @@
 		if(HAS_TRAIT(L, TRAIT_PROSOPAGNOSIA))
 			obscure_name = TRUE
 
-		if(HAS_TRAIT(src, TRAIT_CHARMER))
-			if(gender == L.gender)
-				if(HAS_TRAIT(L, TRAIT_HOMOSEXUAL))
-					L.face_atom(src)
-					L.emote("blush")
-			else
-				if(!HAS_TRAIT(L, TRAIT_HOMOSEXUAL))
-					L.face_atom(src)
-					L.emote("blush")
-
 	var/my_shape = "average"
 	var/my_gender = "male"
 	if(gender == MALE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://github.com/user-attachments/assets/9661d70e-b60b-4c96-ba55-cbefe17d14d8)
It compiles, I examined the pink haired guy on a character without charmer, no blush. 
## Why It's Good For The Game

The blush is really fucking annoying.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Blush no more.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
