### PR TITLE
Removes the few 40 BP bloodpacks from the map

### DIFF
--- a/_maps/map_files/Vampire/SanFrancisco.dmm
+++ b/_maps/map_files/Vampire/SanFrancisco.dmm
@@ -18768,10 +18768,6 @@
 	name = "hideout keys";
 	pixel_x = -2
 	},
-/obj/item/drinkable_bloodpack/vitae{
-	amount_of_bloodpoints = 40;
-	pixel_x = -3
-	},
 /obj/item/clothing/shoes/vampire{
 	max_integrity = 1000;
 	slowdown = -0.3
@@ -43647,10 +43643,6 @@
 	pixel_x = 2;
 	pixel_y = 4
 	},
-/obj/item/drinkable_bloodpack/vitae{
-	amount_of_bloodpoints = 40;
-	pixel_x = -3
-	},
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/bianchiBank)
 "les" = (
@@ -45100,10 +45092,6 @@
 	name = "Elder vitae pack (full)";
 	pixel_x = 2;
 	pixel_y = 4
-	},
-/obj/item/drinkable_bloodpack/vitae{
-	amount_of_bloodpoints = 40;
-	pixel_x = -3
 	},
 /obj/structure/closet/mini_fridge,
 /obj/item/drinkable_bloodpack,
@@ -62453,14 +62441,6 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/laundromat)
-"vbl" = (
-/obj/effect/decal/cardboard,
-/obj/item/drinkable_bloodpack/vitae{
-	amount_of_bloodpoints = 40;
-	pixel_x = -3
-	},
-/turf/open/floor/plating/sidewalk/poor,
-/area/vtm/ghetto)
 "vbm" = (
 /obj/machinery/light/small/red{
 	dir = 1
@@ -67080,13 +67060,6 @@
 /obj/effect/decal/litter,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/sewer)
-"xpW" = (
-/obj/item/drinkable_bloodpack/vitae{
-	amount_of_bloodpoints = 40;
-	pixel_x = -3
-	},
-/turf/open/floor/plating/vampgrass,
-/area/vtm/pacificheights)
 "xpZ" = (
 /obj/machinery/light/small{
 	pixel_y = 32
@@ -150669,7 +150642,7 @@ bfM
 bfM
 bfM
 bfM
-xpW
+bfM
 bfM
 bfL
 bfM
@@ -187895,7 +187868,7 @@ bfO
 bfM
 bfM
 bfM
-xpW
+bfM
 bfM
 bfM
 bfM
@@ -195669,7 +195642,7 @@ aiD
 aiD
 aiD
 aiz
-vbl
+ajW
 uYf
 akd
 abY
@@ -197408,7 +197381,7 @@ bfM
 bfM
 bfM
 bfM
-xpW
+bfM
 bfM
 bfM
 beL


### PR DESCRIPTION
## About The Pull Request

Builds on #715 that was nuked in the rebasing process. I could not reach the contributor for weeks and they missed some bloodpacks, so I'll just fix it myself and attribute it to them

## Why It's Good For The Game

These bloodpacks were the epitome of "if you dive into the game files, you get overpowered stuff". They had no ingame indicator that they refilled 1.5x the full blood pull of a gen7 vampire's. silliness

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

they do be no longer here

![image](https://github.com/user-attachments/assets/6d885eef-1812-46c7-b45d-696a95391506)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Miraviel, xxxnoscopexx:
del: Removed some nonsensinal 40 BP-refilling bloodpacks from the map.
/:cl:
