### PR TITLE
Fixes hallucination fire stacks lingering

### DIFF
--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -1357,6 +1357,7 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 	var/active = TRUE
 	var/stage = 0
 	var/image/fire_overlay
+	var/fire_stack_num = 0.1
 
 	var/next_action = 0
 	var/times_to_lower_stamina
@@ -1367,7 +1368,7 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 /datum/hallucination/fire/New(mob/living/carbon/C, forced = TRUE)
 	set waitfor = FALSE
 	..()
-	target.set_fire_stacks(max(target.fire_stacks, 0.1)) //Placebo flammability
+	target.set_fire_stacks(max(target.fire_stacks, fire_stack_num)) //Placebo flammability
 	fire_overlay = image('icons/mob/OnFire.dmi', target, "Standing", ABOVE_MOB_LAYER)
 	if(target.client)
 		target.client.images += fire_overlay
@@ -1436,6 +1437,7 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 	QDEL_NULL(fire_overlay)
 	fire_clearing = TRUE
 	next_action = 0
+	target.fire_stacks = max(target.fire_stacks - fire_stack_num, 0)
 
 #undef RAISE_FIRE_COUNT
 #undef RAISE_FIRE_TIME


### PR DESCRIPTION
## About The Pull Request

When you get set on fire from the fire hallucination, you get 0.1 fire stack.
This does not go away after the hallucination is done, so all malkavians walk around "covered in something flammable".

With this, the stack goes away with or without putting yourself out.

## Why It's Good For The Game

Detecting Malkavians won't be as easy as shift-clicking them.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/744ed56d-90ec-45e2-8c1b-df8798929ba4)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The Malkavian fire hallucination no longer has lingering fire stacks, meaning Malkavians won't have the "covered in something flammable" examine text for the whole round.
/:cl:
