### PR TITLE
Fixes vests not holding anything in the suit storage

### DIFF
--- a/code/modules/wod13/clothcode.dm
+++ b/code/modules/wod13/clothcode.dm
@@ -781,6 +781,12 @@
 	desc = "Durable, lightweight vest designed to protect against most threats efficiently."
 	icon_state = "vest"
 	armor = list(MELEE = 55, BULLET = 55, LASER = 10, ENERGY = 10, BOMB = 55, BIO = 0, RAD = 0, FIRE = 45, ACID = 10, WOUND = 25)
+	allowed = list(
+		/obj/item/card/id,
+		/obj/item/flashlight,
+		/obj/item/melee/classic_baton/vampire,
+		/obj/item/restraints/handcuffs
+	)
 
 /obj/item/clothing/suit/vampire/vest/medieval
 	name = "medieval vest"


### PR DESCRIPTION
## About The Pull Request

This PR allows the following items to be worn on vests and its subtypes:
- flashlight
- baton
- handcuffs
- ID/badges

## Why It's Good For The Game

Adds (mainly) police vests extra functionality.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/bb60312f-6479-4fb4-bfed-d71152864c2d)

![image](https://github.com/user-attachments/assets/41015b4b-901b-43c3-af65-b58694f27ce8)

![image](https://github.com/user-attachments/assets/6ff50836-7106-4962-be74-b081cbfd7c29)

![image](https://github.com/user-attachments/assets/754afe94-259c-49b0-a66a-a180d7270fc7)

</details>

## Changelog

:cl:
fix: Vests can now hold the following items: flashlight, police baton, IDs, handcuffs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
