### PR TITLE
Fixes the sheriff not having access to seneschal doors

### DIFF
--- a/code/modules/wod13/doorcode.dm
+++ b/code/modules/wod13/doorcode.dm
@@ -53,7 +53,8 @@
 		"prince",
 		"archive",
 		"milleniumCommon",
-		"primogen"
+		"primogen",
+		"clerk"
 	)
 	color = "#bd3327"
 


### PR DESCRIPTION
## About The Pull Request

Adds clerk access to the sheriff keys, so they can access the receptionist.

## Why It's Good For The Game

They cannot access some areas of the Tower and as the de facto head of security, this should not be the case (they already have prince access).

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/958afdab-e39e-463f-b284-a525751fd28a)

</details>

## Changelog

:cl:
fix: Fixes the Sheriff not having access to certain doors in the Millenium Tower.
/:cl:
