### PR TITLE
Drinkable Blood comes from the Hospital

### DIFF
--- a/code/modules/wod13/cargo.dm
+++ b/code/modules/wod13/cargo.dm
@@ -24,20 +24,6 @@
 	contains = list(/obj/item/wire_cutters, /obj/item/storage/box/lights/mixed)
 	crate_name = "weapon crate"
 
-/datum/supply_pack/vampire/bloodpack
-	name = "Blood Pack"
-	desc = "Contains 5 default blood packs."
-	cost = 100
-	contains = list(/obj/item/drinkable_bloodpack, /obj/item/drinkable_bloodpack, /obj/item/drinkable_bloodpack, /obj/item/drinkable_bloodpack, /obj/item/drinkable_bloodpack)
-	crate_name = "blood crate"
-
-/datum/supply_pack/vampire/bloodpack_elite
-	name = "Elite Blood Pack"
-	desc = "Contains 5 elite blood packs."
-	cost = 300
-	contains = list(/obj/item/drinkable_bloodpack/elite, /obj/item/drinkable_bloodpack/elite, /obj/item/drinkable_bloodpack/elite, /obj/item/drinkable_bloodpack/elite, /obj/item/drinkable_bloodpack/elite)
-	crate_name = "blood crate"
-
 /datum/supply_pack/vampire/weaponstake
 	name = "Weapon (stake)"
 	desc = "Contains 3 usable wooden stakes."

--- a/code/modules/wod13/flavledders.dm
+++ b/code/modules/wod13/flavledders.dm
@@ -14,9 +14,8 @@
 		if(do_after(user, 50, src))
 			climbing = FALSE
 			var/turf/destination = get_step_multiz(src, UP)
-			var/mob/living/L = user
-			if(L.pulling)
-				L.pulling.forceMove(destination)
+			if(user.pulling)
+				user.pulling.forceMove(destination)
 			user.forceMove(destination)
 			playsound(src, 'code/modules/wod13/sounds/manhole.ogg', 50, TRUE)
 		else
@@ -49,6 +48,26 @@
 			var/turf/destination = get_step_multiz(src, DOWN)
 			var/mob/living/L = user
 			if(L.pulling)
+				if(istype(L.pulling, /mob/living/carbon/human/npc))
+					var/mob/living/carbon/human/npc/NPC = L.pulling
+					var/witness_count
+					for(var/mob/living/carbon/human/npc/NEPIC in viewers(7, user))
+						if(NEPIC && NEPIC.stat != DEAD)
+							NEPIC.Aggro(L)
+							witness_count++
+					if(witness_count > 1)
+						SEND_SOUND(user, sound('code/modules/wod13/sounds/sus.ogg', 0, 0, 75))
+						to_chat(user, "<span class='userdanger'><b>SUSPICIOUS ACTION (kidnapping)</b></span>")
+						for(var/obj/item/police_radio/radio in GLOB.police_radios)
+							radio.announce_crime("victim", get_turf(src))
+						for(var/obj/machinery/p25transceiver/police/radio in GLOB.p25_tranceivers)
+							if(radio.p25_network == "police")
+								radio.announce_crime("victim", get_turf(src))
+								break
+					if(NPC.CheckMove())
+						NPC.Aggro(L, TRUE)
+						L.visible_message("<span class='danger'>[NPC.name] resists going down with [src].</span>", "<span class='danger'>[NPC.name] resists going down, breaking your descent.</span>", null, COMBAT_MESSAGE_RANGE, NPC)
+						return
 				L.pulling.forceMove(destination)
 			user.forceMove(destination)
 			playsound(src, 'code/modules/wod13/sounds/manhole.ogg', 50, TRUE)

--- a/code/modules/wod13/flavledders.dm
+++ b/code/modules/wod13/flavledders.dm
@@ -14,8 +14,9 @@
 		if(do_after(user, 50, src))
 			climbing = FALSE
 			var/turf/destination = get_step_multiz(src, UP)
-			if(user.pulling)
-				user.pulling.forceMove(destination)
+			var/mob/living/L = user
+			if(L.pulling)
+				L.pulling.forceMove(destination)
 			user.forceMove(destination)
 			playsound(src, 'code/modules/wod13/sounds/manhole.ogg', 50, TRUE)
 		else
@@ -48,26 +49,6 @@
 			var/turf/destination = get_step_multiz(src, DOWN)
 			var/mob/living/L = user
 			if(L.pulling)
-				if(istype(L.pulling, /mob/living/carbon/human/npc))
-					var/mob/living/carbon/human/npc/NPC = L.pulling
-					var/witness_count
-					for(var/mob/living/carbon/human/npc/NEPIC in viewers(7, user))
-						if(NEPIC && NEPIC.stat != DEAD)
-							NEPIC.Aggro(L)
-							witness_count++
-					if(witness_count > 1)
-						SEND_SOUND(user, sound('code/modules/wod13/sounds/sus.ogg', 0, 0, 75))
-						to_chat(user, "<span class='userdanger'><b>SUSPICIOUS ACTION (kidnapping)</b></span>")
-						for(var/obj/item/police_radio/radio in GLOB.police_radios)
-							radio.announce_crime("victim", get_turf(src))
-						for(var/obj/machinery/p25transceiver/police/radio in GLOB.p25_tranceivers)
-							if(radio.p25_network == "police")
-								radio.announce_crime("victim", get_turf(src))
-								break
-					if(NPC.CheckMove())
-						NPC.Aggro(L, TRUE)
-						L.visible_message("<span class='danger'>[NPC.name] resists going down with [src].</span>", "<span class='danger'>[NPC.name] resists going down, breaking your descent.</span>", null, COMBAT_MESSAGE_RANGE, NPC)
-						return
 				L.pulling.forceMove(destination)
 			user.forceMove(destination)
 			playsound(src, 'code/modules/wod13/sounds/manhole.ogg', 50, TRUE)

--- a/code/modules/wod13/machine_vending.dm
+++ b/code/modules/wod13/machine_vending.dm
@@ -250,6 +250,8 @@
 		new /datum/data/mining_equipment("bruise pack", /obj/item/stack/medical/bruise_pack, 20),
 		new /datum/data/mining_equipment("Compact Defibillator", /obj/item/defibrillator/compact, 25),
 		new /datum/data/mining_equipment("surgery dufflebag", /obj/item/storage/backpack/duffelbag/med/surgery, 50),
+		new /datum/data/mining_equipment("high quality blood pack", /obj/item/drinkable_bloodpack/elite, 20),
+		new /datum/data/mining_equipment("blood pack", /obj/item/drinkable_bloodpack, 5),
 		new /datum/data/mining_equipment("Hospital Radio", /obj/item/p25radio, 50)
 	)
 

--- a/code/modules/wod13/postal.dm
+++ b/code/modules/wod13/postal.dm
@@ -78,7 +78,6 @@
 						/obj/item/stack/dollar/rand,
 						/obj/item/melee/vampirearms/knife,
 						/obj/item/melee/vampirearms/tire,
-						/datum/supply_pack/vampire/bloodpack,
 						/obj/item/gun/ballistic/vampire/revolver,
 						/obj/item/vamp/keys/hack)
 		new IT(user.loc)


### PR DESCRIPTION
## About The Pull Request

Removes blood pack ordering from the depot, and puts it in the hospital. They can directly order elite blood packs from their machine now for vampires, or make it themselves as intended through the machines. Please get blood from the hospital.

## Why It's Good For The Game

In order to give hospitals their more canonical vampire traffic and blood bank usage, blood packs have been moved to the hospital. It should not only fit the lore, but distribute round start pressure between a few locations and encourage preservation of the hospital.

## Testing Photographs and Procedure
<details>

<summary>look, you can get them here</summary>
![image](https://github.com/user-attachments/assets/43850b44-1da2-43e8-8c27-637d499e4fb2)

</details>

## Changelog

:cl: Yinadele
balance: Blood packs and elite blood packs are now requested from the hospital, not the train station.
/:cl:
