### PR TITLE
Ocean turf hotfix: They're dense now

### DIFF
--- a/code/modules/wod13/wallcode.dm
+++ b/code/modules/wod13/wallcode.dm
@@ -1149,14 +1149,7 @@
 	barefootstep = FOOTSTEP_WATER
 	clawfootstep = FOOTSTEP_HARD_CLAW
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
-	density = FALSE
-
-/turf/open/floor/plating/vampocean/Enter(atom/movable/mover, atom/oldloc)
-	if(isliving(mover))
-		var/mob/living/swimmer = mover
-		if(!HAS_TRAIT(swimmer, TRAIT_SUPERNATURAL_DEXTERITY))
-			return FALSE
-	. = ..()
+	density = TRUE
 
 /turf/open/floor/plating/vampocean/Initialize()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The spectre of Flavcode haunts our codebase perpetually. One of them is ocean turfs being open but also preventing things from entering them but only sometimes.

Instead I just made the damn things dense pending a complete rework of how we move in water instead of the snowflake crap we deal with now.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

There's inconsistent behavior with what can enter ocean turfs and there's really no reason to be able to enter them right now, considering there's like, nothing out there. Until we actually need them, having them be dense gives admins and players one less stupid thing to deal with.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.


https://github.com/user-attachments/assets/dcd30ec8-0956-49d5-8399-97d626d56b01




</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Ocean turfs are dense, pending a rework of what we even have ocean turfs for./:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
