### PR TITLE
NPC AI fixes (NPC's drop weapons less, are 50% less psychotic)

### DIFF
--- a/code/modules/wod13/npc_aggression.dm
+++ b/code/modules/wod13/npc_aggression.dm
@@ -59,13 +59,32 @@
 	SIGNAL_HANDLER
 	UnregisterSignal(my_weapon, COMSIG_GUN_FIRED)
 	UnregisterSignal(my_weapon, COMSIG_GUN_EMPTY)
-	if(my_weapon.loc != src)
-		return
-
-	temporarilyRemoveItemFromInventory(my_weapon, TRUE)
-	equip_to_appropriate_slot(my_weapon)
-	has_weapon = FALSE
+	npc_stow_weapon()
 	if(my_backup_weapon && !spawned_backup_weapon)
-		my_backup_weapon.forceMove(loc)
-		put_in_active_hand(my_backup_weapon)
+		npc_draw_backup_weapon()
+		my_weapon = my_backup_weapon
 		spawned_backup_weapon = TRUE
+
+/mob/living/carbon/human/npc/proc/npc_stow_weapon()
+	if(my_weapon)
+		REMOVE_TRAIT(my_weapon, TRAIT_NODROP, NPC_ITEM_TRAIT)
+		temporarilyRemoveItemFromInventory(my_weapon, TRUE)
+		equip_to_appropriate_slot(my_weapon)
+		ADD_TRAIT(my_weapon, TRAIT_NODROP, NPC_ITEM_TRAIT)
+		spawned_weapon = FALSE
+
+/mob/living/carbon/human/npc/proc/npc_draw_weapon()
+	if(my_weapon)
+		REMOVE_TRAIT(my_weapon, TRAIT_NODROP, NPC_ITEM_TRAIT)
+		temporarilyRemoveItemFromInventory(my_weapon, TRUE)
+		put_in_active_hand(my_weapon)
+		ADD_TRAIT(my_weapon, TRAIT_NODROP, NPC_ITEM_TRAIT)
+		spawned_weapon = TRUE
+
+/mob/living/carbon/human/npc/proc/npc_draw_backup_weapon()
+	if(my_backup_weapon)
+		REMOVE_TRAIT(my_backup_weapon, TRAIT_NODROP, NPC_ITEM_TRAIT)
+		temporarilyRemoveItemFromInventory(my_backup_weapon, TRUE)
+		put_in_active_hand(my_backup_weapon)
+		ADD_TRAIT(my_backup_weapon, TRAIT_NODROP, NPC_ITEM_TRAIT)
+		spawned_weapon = TRUE

--- a/code/modules/wod13/npc_movement.dm
+++ b/code/modules/wod13/npc_movement.dm
@@ -260,11 +260,7 @@
 				var/obj/item/card/id/id_card = danger_source.get_idcard(FALSE)
 				if(!istype(id_card, /obj/item/card/id/police) || is_criminal)
 					if(!spawned_weapon && has_weapon)
-						my_weapon.forceMove(loc)
-						drop_all_held_items()
-						temporarilyRemoveItemFromInventory(my_weapon, TRUE)
-						put_in_active_hand(my_weapon)
-						spawned_weapon = TRUE
+						npc_draw_weapon()
 					if(spawned_weapon && get_active_held_item() != my_weapon)
 						has_weapon = FALSE
 					if(danger_source)
@@ -283,9 +279,7 @@
 					danger_source = null
 					if(has_weapon)
 						if(get_active_held_item() == my_weapon)
-							drop_all_held_items()
-							my_weapon.forceMove(src)
-							spawned_weapon = FALSE
+							npc_stow_weapon()
 						else
 							has_weapon = FALSE
 					walktarget = ChoosePath()
@@ -295,9 +289,7 @@
 				danger_source = null
 				if(has_weapon)
 					if(get_active_held_item() == my_weapon)
-						drop_all_held_items()
-						my_weapon.forceMove(src)
-						spawned_weapon = FALSE
+						npc_stow_weapon()
 					else
 						has_weapon = FALSE
 				walktarget = ChoosePath()
@@ -318,8 +310,6 @@
 		if(has_weapon && !danger_source)
 			if(spawned_weapon)
 				if(get_active_held_item() == my_weapon)
-					drop_all_held_items()
-					my_weapon.forceMove(src)
-					spawned_weapon = FALSE
+					npc_stow_weapon()
 				else
 					has_weapon = FALSE

--- a/code/modules/wod13/npcroles.dm
+++ b/code/modules/wod13/npcroles.dm
@@ -781,7 +781,7 @@
 
 /mob/living/carbon/human/npc/bandit
 	max_stat = 3
-	my_backup_weapon = /obj/item/melee/vampirearms/knife
+	my_backup_weapon_type = /obj/item/melee/vampirearms/knife
 
 /mob/living/carbon/human/npc/bandit/Initialize()
 	. = ..()


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- NPCs Now only drop their weapons items on death
- NPCs do not aggro at first when being hit by attacks below a certain threshhold 
- NPCs do not aggro at first when items below a certain throw force are thrown at them
- Simplified parts of the NPC AI code so it will be easier to rewrite in the future

## Why It's Good For The Game

NPC's are too easy to kill and too easy to rile up. This will make them slower to anger and scarier when angered.

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/dd6432e6-0400-4ffc-89e8-ca5f040d2b88


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

balance: NPCs Now only drop their weapons items on death
balance: NPCs do not aggro at first when being hit by attacks below a certain threshhold 
balance: NPCs do not aggro at first when items below a certain throw force are thrown at them
refactor: Simplified parts of the NPC AI code so it will be easier to rewrite in the future
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
