### PR TITLE
Troll-proof lockpicking

### DIFF
--- a/code/modules/wod13/structures/doors/vampdoor.dm
+++ b/code/modules/wod13/structures/doors/vampdoor.dm
@@ -15,7 +15,7 @@
 
 	var/closed = TRUE
 	var/locked = FALSE
-	var/lock_id = "nothing"
+	var/lock_id = null
 	var/glass = FALSE
 	var/hacking = FALSE
 	var/lockpick_timer = 17 //[Lucifernix] - Never have the lockpick timer lower than 7. At 7 it will unlock instantly!!
@@ -169,7 +169,7 @@
 				hacking = FALSE
 				return
 		else
-			if (closed) //yes, this is a thing you can extremely easily do in real life
+			if (closed && lock_id) //yes, this is a thing you can extremely easily do in real life
 				to_chat(user, "<span class='notice'>You re-lock the door with your lockpick.</span>")
 				locked = TRUE
 				playsound(src, 'code/modules/wod13/sounds/hack.ogg', 100, TRUE)

--- a/code/modules/wod13/structures/doors/vampdoor.dm
+++ b/code/modules/wod13/structures/doors/vampdoor.dm
@@ -169,7 +169,7 @@
 				hacking = FALSE
 				return
 		else
-			if (closed && lock_id) //yes, this is a thing you can extremely easily do in real life
+			if (closed && lock_id) //yes, this is a thing you can extremely easily do in real life... FOR DOORS WITH LOCKS!
 				to_chat(user, "<span class='notice'>You re-lock the door with your lockpick.</span>")
 				locked = TRUE
 				playsound(src, 'code/modules/wod13/sounds/hack.ogg', 100, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so that only doors with lock perms can be locked with lockpicks

## Why It's Good For The Game

Trolls have been going around locking doors with lockpicks for fun. 

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/user-attachments/assets/f507b9b7-aa42-4b3f-aafc-08fca2f3d386



</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: lockpicks can only lock doors that lock
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
