### PR TITLE
The PD Armoury - Minor update to REQ and the PD

### DIFF
--- a/_maps/map_files/Vampire/SanFrancisco.dmm
+++ b/_maps/map_files/Vampire/SanFrancisco.dmm
@@ -38828,7 +38828,9 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/pacificheights)
 "isj" = (
-/obj/structure/sign/warning/securearea,
+/obj/structure/sign/warning/securearea{
+	pixel_y = 13
+	},
 /turf/closed/wall/vampwall/painted,
 /area/vtm/interior/police)
 "isn" = (
@@ -54138,6 +54140,10 @@
 /obj/effect/decal/litter,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior)
+"qIm" = (
+/obj/structure/table/reinforced,
+/turf/closed/wall/vampwall/painted/low,
+/area/vtm/interior/police)
 "qIu" = (
 /obj/machinery/processor,
 /turf/open/floor/plating/toilet,
@@ -251952,7 +251958,7 @@ gHF
 pWI
 cyz
 isj
-aDl
+qIm
 aDl
 azv
 aiA

--- a/_maps/map_files/Vampire/SanFrancisco.dmm
+++ b/_maps/map_files/Vampire/SanFrancisco.dmm
@@ -24665,11 +24665,6 @@
 /obj/structure/curtain/cloth/fancy,
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/f2)
-"bGg" = (
-/obj/effect/decal/bordur,
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/vampwall/painted,
-/area/vtm/interior/police)
 "bGh" = (
 /turf/open/openspace,
 /area/vtm/church)
@@ -38833,7 +38828,7 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/pacificheights)
 "isj" = (
-/obj/keypad/pd,
+/obj/structure/sign/warning/securearea,
 /turf/closed/wall/vampwall/painted,
 /area/vtm/interior/police)
 "isn" = (
@@ -46438,10 +46433,10 @@
 /turf/open/floor/plating/vampcanalplating,
 /area/vtm/interior/glasswalker)
 "mxS" = (
-/obj/machinery/light/small{
-	pixel_y = 32
+/obj/keypad/pd{
+	pixel_y = 29
 	},
-/turf/closed/wall/vampwall/painted/low/window/reinforced,
+/turf/open/floor/plating/toilet,
 /area/vtm/interior/police)
 "myf" = (
 /obj/structure/table,
@@ -49807,6 +49802,11 @@
 	name = "Police Sergeant"
 	},
 /obj/effect/decal/cleanable/feet_trail,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#6488EA";
+	pixel_x = 16
+	},
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/police)
 "ovs" = (
@@ -251435,8 +251435,8 @@ azv
 azv
 bZh
 wHA
-bGg
-laj
+pWI
+mxS
 laj
 laj
 pHL
@@ -251952,7 +251952,7 @@ gHF
 pWI
 cyz
 isj
-mxS
+aDl
 aDl
 azv
 aiA

--- a/_maps/map_files/Vampire/SanFrancisco.dmm
+++ b/_maps/map_files/Vampire/SanFrancisco.dmm
@@ -20490,6 +20490,8 @@
 /obj/effect/turf_decal/stripes{
 	dir = 4
 	},
+/obj/structure/table/reinforced,
+/obj/item/grenade/smokebomb,
 /turf/open/floor/plating/vampplating,
 /area/vtm/interior/police)
 "bsE" = (
@@ -26651,9 +26653,6 @@
 /obj/effect/turf_decal/stripes{
 	dir = 4
 	},
-/obj/american_flag{
-	pixel_y = 32
-	},
 /turf/open/floor/plating/vampplating,
 /area/vtm/interior/police)
 "ccB" = (
@@ -27543,13 +27542,11 @@
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/millennium_tower/ventrue)
 "cyz" = (
-/obj/structure/vampdoor/police/secure{
-	color = "#466a72";
-	dir = 4;
-	lockpick_difficulty = 23
-	},
 /obj/effect/turf_decal/siding/white{
 	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/pd{
+	dir = 8
 	},
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/police)
@@ -33751,6 +33748,9 @@
 	desc = "SFPD Breacher equipment. Provides best protection against nearly everything.";
 	name = "SFPD EOD suit"
 	},
+/obj/machinery/light/dim{
+	pixel_y = 32
+	},
 /turf/open/floor/plating/vampplating,
 /area/vtm/interior/police)
 "fPk" = (
@@ -38344,10 +38344,14 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/laundromat)
 "ifO" = (
-/obj/structure/table/reinforced,
-/obj/item/gun/ballistic/shotgun/vampire,
-/obj/item/ammo_box/vampire/c12g/buck,
-/turf/closed/wall/vampwall/painted/low,
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/structure/closet/crate,
+/obj/item/gun/ballistic/automatic/vampire/sniper,
+/obj/item/ammo_box/vampire/c50,
+/obj/item/ammo_box/vampire/c50,
+/turf/open/floor/plating/vampplating,
 /area/vtm/interior/police)
 "ifW" = (
 /obj/structure/weedshit,
@@ -38829,9 +38833,8 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/pacificheights)
 "isj" = (
-/obj/effect/decal/bordur,
-/obj/effect/decal/wallpaper/blue/low,
-/turf/closed/wall/vampwall/painted/low/window/reinforced,
+/obj/keypad/pd,
+/turf/closed/wall/vampwall/painted,
 /area/vtm/interior/police)
 "isn" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -40753,6 +40756,9 @@
 /obj/effect/turf_decal/stripes{
 	dir = 4
 	},
+/obj/structure/table/reinforced,
+/obj/item/storage/box/handcuffs,
+/obj/item/food/donut/choco,
 /turf/open/floor/plating/vampplating,
 /area/vtm/interior/police)
 "jnN" = (
@@ -46432,13 +46438,10 @@
 /turf/open/floor/plating/vampcanalplating,
 /area/vtm/interior/glasswalker)
 "mxS" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/handcuffs,
-/obj/item/food/donut/choco,
 /obj/machinery/light/small{
 	pixel_y = 32
 	},
-/turf/closed/wall/vampwall/painted/low,
+/turf/closed/wall/vampwall/painted/low/window/reinforced,
 /area/vtm/interior/police)
 "myf" = (
 /obj/structure/table,
@@ -248601,7 +248604,7 @@ uMy
 nfu
 dex
 azv
-wQh
+wvi
 aAN
 aAN
 aAN
@@ -251948,9 +251951,9 @@ ltc
 gHF
 pWI
 cyz
-azv
+isj
 mxS
-ifO
+aDl
 azv
 aiA
 aiA
@@ -252207,7 +252210,7 @@ tJI
 ktm
 cRm
 iJw
-cRm
+ifO
 azv
 byD
 aiA
@@ -252460,7 +252463,7 @@ hGC
 azv
 hrZ
 aAN
-isj
+tJI
 ugl
 uQL
 uQL
@@ -252717,7 +252720,7 @@ cvu
 fVX
 nzM
 aAN
-isj
+tJI
 fPd
 uQL
 uQL

--- a/code/game/machinery/doors/shutters.dm
+++ b/code/game/machinery/doors/shutters.dm
@@ -63,3 +63,9 @@
 	ertblast = TRUE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	id = 11
+
+/obj/machinery/door/poddoor/shutters/pd
+	name = "armory shutters"
+	ertblast = TRUE
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	id = 13

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -283,15 +283,12 @@
 		new /datum/data/mining_equipment("mp5 magazine",			/obj/item/ammo_box/magazine/vamp9mp5, 20),
 		new /datum/data/mining_equipment("Glock19",					/obj/item/gun/ballistic/automatic/vampire/glock19,	25),
 		new /datum/data/mining_equipment("Colt M1911",				/obj/item/gun/ballistic/automatic/vampire/m1911,	25),
-		new /datum/data/mining_equipment("SPAS15 magazine",			/obj/item/ammo_box/magazine/vampautoshot,	30),
 		new /datum/data/mining_equipment("12ga slug",				/obj/item/ammo_box/vampire/c12g,	35),
 		new /datum/data/mining_equipment("PD Radio", 				/obj/item/p25radio/police, 50),
 		new /datum/data/mining_equipment("shotgun",					/obj/item/gun/ballistic/shotgun/vampire, 50),
 		new /datum/data/mining_equipment("submachine gun",			/obj/item/gun/ballistic/automatic/vampire/mp5, 100),
 		new /datum/data/mining_equipment("assault rifle",			/obj/item/gun/ballistic/automatic/vampire/ar15, 125),
-		new /datum/data/mining_equipment("SPAS15",					/obj/item/gun/ballistic/automatic/vampire/autoshotgun, 200),
-		new /datum/data/mining_equipment("sniper rifle",			/obj/item/gun/ballistic/automatic/vampire/sniper, 300),
-	)	//PSEUDO_M todo: add .50 ammo to this list
+	)	//Removing the SPAS15 and moving the Sniper to the Armoury because I hate fun
 
 /obj/machinery/mineral/equipment_vendor/proc/RedeemVoucher(obj/item/mining_voucher/voucher, mob/redeemer)
 	var/items = list("Survival Capsule and Explorer's Webbing", "Resonator Kit", "Minebot Kit", "Extraction and Rescue Kit", "Crusher Kit", "Mining Conscription Kit")

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -273,6 +273,7 @@
 		new /datum/data/mining_equipment("magnifier", /obj/item/detective_scanner, 2),
 		new /datum/data/mining_equipment("body bags", /obj/item/storage/box/bodybags, 5),
 		new /datum/data/mining_equipment("police vest", /obj/item/clothing/suit/vampire/vest/police, 5),
+		new /datum/data/mining_equipment("smoke grenade",			/obj/item/grenade/smokebomb, 5),
 		new /datum/data/mining_equipment("Colt M1911 magazine",		/obj/item/ammo_box/magazine/vamp45acp,	10),
 		new /datum/data/mining_equipment("AUG Magazines",			/obj/item/ammo_box/magazine/vampaug,	10),
 		new /datum/data/mining_equipment("AR-15 Magazines",			/obj/item/ammo_box/magazine/vamp556,	10),

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -85,7 +85,7 @@
 			for(var/i in host.knowscontacts)
 				dat += "-[i] contact<BR>"
 		var/obj/keypad/pd/pd = find_keypad(/obj/keypad/pd)
-		if(pddoor && (host.mind.assigned_role == "Police Chief" || host.mind.assigned_role == "Police Sergeant"))
+		if(pd && (host.mind.assigned_role == "Police Chief" || host.mind.assigned_role == "Police Sergeant"))
 			dat += "The pincode for the armory keypad is<b>: [pd.pincode]</b><BR>"
 		for(var/datum/vtm_bank_account/account in GLOB.bank_account_list)
 			if(host.bank_id == account.bank_id)

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -84,6 +84,9 @@
 			dat += "<b>I know some other of my kind in this city. Need to check my phone, there definetely should be:</b><BR>"
 			for(var/i in host.knowscontacts)
 				dat += "-[i] contact<BR>"
+		var/obj/keypad/pd/pd = find_keypad(/obj/keypad/pd)
+		if(pddoor && (host.mind.assigned_role == "Police Chief" || host.mind.assigned_role == "Police Sergeant"))
+			dat += "The pincode for the armory keypad is<b>: [pd.pincode]</b><BR>"
 		for(var/datum/vtm_bank_account/account in GLOB.bank_account_list)
 			if(host.bank_id == account.bank_id)
 				dat += "<b>My bank account code is: [account.code]</b><BR>"

--- a/code/modules/vtmb/electronics/keypads/keypad.dm
+++ b/code/modules/vtmb/electronics/keypads/keypad.dm
@@ -32,6 +32,10 @@
 	id = 11
 	..()
 
+/obj/machinery/door/poddoor/shutters/pd/New()
+	id = 13
+	..()
+
 /proc/find_keypad(keypad_type)
     for(var/obj/keypad/K in world)
         if(istype(K, keypad_type))
@@ -76,3 +80,6 @@
 
 /obj/keypad/panic_room
 	id = 12
+
+/obj/keypad/pd
+	id = 13


### PR DESCRIPTION
## About The Pull Request

'What do you MEAN I can't have all my officers equipped with 50 cals? I'm the god damn Chief of San Francisco PD and I can do as I please!'

Two minor updates, to the Requestions shop and the Armoury.

A. Armoury now is accessed via a pincode, which both Police Sergeants and Police Chiefs know of. This is done to ward off against lockpicks and because if the tower can have a fancy armoury opening then god damn do we want one as well. Certain windows have been removed as well, and a photocopier was added to the second story of the PD.

B. Req no longer dispenses Snipers and SPAS auto shotties, with the sniper being moved to the Armoury alongside some 50cal ammo. Smoke grenade was also added onto there.

## Why It's Good For The Game

Firstly, the fancy pin-code doors are sick. The removal of the windows also makes the room feel more secure instead of letting literally everyone peak inside. The removal of the SPAS was because it's just an upgrade from the shotgun. There's no need to have a normal shotgun around if any officer can just buy an automatic one which is easier to use and far more effective. Ideally, it'd be an National Guard or SWAT weapon to highlight their role as an equaliser (SWAT update coming soon)

Sniper was moved because the Chief could give 12 50cals to their officers to turn even the most robust gen 7 into swiss cheese with one firing line. Alongside this, there was no ammunition to go along with the sniper, so officers had 5 rounds to conserve against an enemy. Finally, smoke grenades are cool and even if they're a debuff from the pepper grenades, only the chief have those available with them. Also they're cool.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/7c27b918-8406-4819-994a-e000adcc20ad)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: New fancy pin-code door, allowing the PD to actually use it as well. Moved the 50cal to the Armoury with ammo. Adds a new photocopier to the upper PD.
del: SPAS and Sniper from the Req
map: PD upper layer (Mostly armoury)
spellcheck: fixed a few typos
code: Human sergeants and chiefs now know the pin to the Armoury in About Me.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
