### PR TITLE
Fixes a Visible Matrix in NosTown and the Clinic Garage Door Access

### DIFF
--- a/_maps/map_files/Vampire/SanFrancisco.dmm
+++ b/_maps/map_files/Vampire/SanFrancisco.dmm
@@ -5646,7 +5646,7 @@
 /obj/machinery/door/poddoor/shutters{
 	damage_deflection = 50;
 	dir = 4;
-	id = "pentex_exec";
+	id = "clinic";
 	max_integrity = 200;
 	name = "Parking Shutter"
 	},
@@ -80732,7 +80732,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aab
 aab
 aab
 aab
@@ -80989,8 +80989,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aab
+aaj
 aaj
 aaj
 aaj
@@ -81247,9 +81247,9 @@ aaa
 aaa
 aaa
 aab
-xfd
 aaj
 aal
+aaj
 aal
 aal
 aal


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR fixes a poorly mapped corner in the caves of NosTown that left a visible matrix, as well as fixing the Clinic Garage door to have the appropriate ID, so it should no longer be linked to the Pentex Executive's button :)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Matrixes being randomly visible is frowned upon. Pentex owning the Clinic Garage Door makes little sense (and was an oversight of the Endron mappers).

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Photographs and Procedure

These are extremely minor changes, but let me know if you think it is essential I provide a loaded in view of them.

![image](https://github.com/user-attachments/assets/3f7cf0e6-859b-499b-b6d5-c34f917f42f4)
![image](https://github.com/user-attachments/assets/f5778af5-a0e0-4fc3-b962-f1be065ef109)

<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
map: Fixed a visible matrix in Nos Town.
map: Fixed the Clinic Garage being linked to Pentex Executive access.
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
