### PR TITLE
Removes the ability to transform living Garou into Ghouls

### DIFF
--- a/code/modules/vtmb/kindred_species.dm
+++ b/code/modules/vtmb/kindred_species.dm
@@ -346,7 +346,7 @@
 			L.adjustFireLoss(-25)
 		if(istype(H.pulling, /mob/living/carbon/human))
 			var/mob/living/carbon/human/BLOODBONDED = H.pulling
-			if(iscathayan(BLOODBONDED))
+			if(iscathayan(BLOODBONDED) || ((isgarou(BLOODBONDED) || iswerewolf(BLOODBONDED)) && BLOODBONDED.stat != DEAD ))
 				to_chat(owner, "<span class='warning'>[BLOODBONDED] vomits the vitae back!</span>")
 				return
 			if(!BLOODBONDED.client && !istype(H.pulling, /mob/living/carbon/human/npc))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR makes it so you can no longer turn living Garou into ghouls. You can still however try to embrace dead Garou to create Abominations.

Currently if you get ghouled as a Garou you lose all unique features and all ability buttons disappear. The HUD elements for shapeshifting and the like on the right remain, although they become dysfunctional. This is clearly not intended behavior and quite broken.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Vampires shouldn't be able to turn Garou into regular human ghouls.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>

![werewolves vomitting up blood now](https://github.com/user-attachments/assets/ec79f9dc-bb2a-430e-b4d9-72b6b4856f01)

<!-- Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags. -->

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Living Garou can no longer be turned into Ghouls.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
