### PR TITLE
Makes the cost of raising your Dharma level scale with level (also, a non-critical but substantial bug fix)

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2292,10 +2292,10 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					enlightenment = !enlightenment
 
 				if("dharmarise")
-					if ((true_experience < 20) || (dharma_level >= 6) || !(pref_species.id == "kuei-jin"))
+					if ((true_experience < min((dharma_level * 5), 20)) || (dharma_level >= 6) || !(pref_species.id == "kuei-jin"))
 						return
 
-					true_experience -= 20
+					true_experience -= min((dharma_level * 5), 20)
 					dharma_level = clamp(dharma_level + 1, 1, 6)
 
 					if (dharma_level >= 6)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -3088,7 +3088,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		var/dharma_bonus = 0
 		if(pref_species.name == "Kuei-Jin")
 			dharma_bonus = dharma_level
-		character.maxHealth = round((initial(character.maxHealth)-initial(character.maxHealth)/4)+(initial(character.maxHealth)/4)*((character.physique+character.additional_physique )+13-generation+dharma_bonus))
+		character.maxHealth = round((initial(character.maxHealth)-initial(character.maxHealth)/4)+(initial(character.maxHealth)/4)*((character.physique+character.additional_physique)+dharma_bonus))
 		character.health = character.maxHealth
 	if(pref_species.name == "Vampire")
 		character.humanity = humanity

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -464,8 +464,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				var/datum/dharma/D = new dharma_type()
 				dat += "<b>Dharma:</b> [D.name] [dharma_level]/6 <a href='?_src_=prefs;preference=dharmatype;task=input'>Switch</a><BR>"
 				dat += "[D.desc]<BR>"
-				if(true_experience >= 20 && (dharma_level < 6))
-					dat += " <a href='?_src_=prefs;preference=dharmarise;task=input'>Learn (20)</a><BR>"
+				if(true_experience >= min((dharma_level * 5), 20) && (dharma_level < 6))
+					var/dharma_cost = min((dharma_level * 5), 20)
+					dat += " <a href='?_src_=prefs;preference=dharmarise;task=input'>Learn ([dharma_cost])</a><BR>"
 				dat += "<b>P'o Personality</b>: [po_type] <a href='?_src_=prefs;preference=potype;task=input'>Switch</a><BR>"
 				dat += "<b>Awareness:</b> [masquerade]/5<BR>"
 				dat += "<b>Yin/Yang</b>: [yin]/[yang] <a href='?_src_=prefs;preference=chibalance;task=input'>Adjust</a><BR>"

--- a/code/modules/vtmb/dharma.dm
+++ b/code/modules/vtmb/dharma.dm
@@ -88,7 +88,7 @@
 			var/datum/action/area_chi/areac = new()
 			areac.Grant(mob)
 
-	mob.maxHealth = initial(mob.maxHealth) + (initial(mob.maxHealth) / 4) * mob.mind.dharma.level
+	mob.maxHealth = floor(initial(mob.maxHealth)-(initial(mob.maxHealth)/4)+(initial(mob.maxHealth)/4*((mob.physique+mob.additional_physique)+level)))
 	mob.health = mob.maxHealth
 
 /**


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Previously, Kuei-jin had to spend 20 XP for each Dharma level. This PR changes that cost to 5 XP per current level to a maximum of 20, so the costs are 5, 10, 15, 20, 20.
Also fixes the way Kuei-jin max HP is calculated, because this didn't properly take both physique and dharma into account.

## Why It's Good For The Game

The benefits of Dharma levels 2-4 are limited to +25 HP, and 20XP is just a crazy cost for that at the moment - Physique does that and more! Only 5 and 6 provide any other benefit, those being other ways to draw chi (very useful) and an increase to your maximum resources.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/cbbfa82e-5748-4731-b486-c43c3620ad5e)
I have 935 XP.
![image](https://github.com/user-attachments/assets/f812f3b5-55e0-4830-8be5-4997c054d559)
I now have 925 XP.
![image](https://github.com/user-attachments/assets/765f743f-49c8-43d3-97bc-119db69ef858)
The above image was taken with 6 physique and Dharma 3.
![image](https://github.com/user-attachments/assets/40ae3033-6e83-44a0-85dc-d6f0d0ad3b54)
This one was taken with 5 physique and Dharma 6.
</details>

## Changelog



:cl:
balance: kuei-jin only need to pay 5, 10, and 15 XP for the first three dharma rises
fix: kuei-jin should have the correct HP for their level and stats
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
