### PR TITLE
Changes the amount of ghouls that can be playing the Police Officer role simultaneously from one to two.

### DIFF
--- a/code/modules/vtmb/jobs/police.dm
+++ b/code/modules/vtmb/jobs/police.dm
@@ -18,7 +18,7 @@
 	exp_type_department = EXP_TYPE_POLICE
 
 	allowed_species = list("Ghoul", "Human")
-	species_slots = list("Ghoul" = 1)
+	species_slots = list("Ghoul" = 2)
 
 	duty = "Enforce the Law."
 	minimal_masquerade = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This pull request simply increases the number of ghouls that can be playing the Police Officer role simultaneously from one, to two.

## Why It's Good For The Game

While there's nothing wrong with the current state of affairs (even though it is annoying when I can't play because of it), if you're going to allow one, why not two?

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Changes the amount of ghouls that can be police officer from one to two
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
