### PR TITLE
Fix new cargo code warning

### DIFF
--- a/code/modules/wod13/cargo.dm
+++ b/code/modules/wod13/cargo.dm
@@ -50,7 +50,7 @@
 	cost = 300
 	contains = list(/obj/item/binoculars)
 
-datum/supply_pack/vampire/medicalsupplies
+/datum/supply_pack/vampire/medicalsupplies
 	name = "Medical Supplies"
 	desc = "Contains some first aid supplies."
 	cost = 500
@@ -179,7 +179,7 @@ datum/supply_pack/vampire/medicalsupplies
 	contains = list(/obj/item/gun/ballistic/automatic/vampire/deagle, /obj/item/ammo_box/magazine/m44)
 	crate_name = "weapon crate"
 
-datum/supply_pack/vampire/weapondeagle50
+/datum/supply_pack/vampire/weapondeagle50
 	name = "Weapon (desert eagle 50AE)"
 	desc = "Contains a .50 caliber desert eagle."
 	cost = 2000
@@ -398,7 +398,7 @@ datum/supply_pack/vampire/weapondeagle50
 	name = "Ammo (3x Desert Eagle 50AE magazines)"
 	desc = "Contains three desert eagle 50AE magazines."
 	cost = 1200
-	contains = list(/obj/item/ammo_box/magazine/m50, /obj/item/ammo_box/magazine/m50)
+	contains = list(/obj/item/ammo_box/magazine/m50, /obj/item/ammo_box/magazine/m50, /obj/item/ammo_box/magazine/m50)
 	crate_name = "ammo crate"
 
 /datum/supply_pack/vampire/magazine_mp5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Two warnings were introduced as a result of someone forgetting to put slashes before their type declaration, and they accidentally made the AE desert eagle order say it orders three boxes while it actually orders two. This gets rid of the warning and makes it actually order three boxes.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No parser warnings = life is good.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>

<summary>Screenshots&Videos</summary>

![Code_vasAZTdCi7](https://github.com/user-attachments/assets/9dee6a84-fdd0-495b-9af9-67e289dd994d)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
Fixed parser warning from the cargo PR.
Made the Desert Eagle 3 AE ammo box order actually order 3 boxes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
