### PR TITLE
Reworks Armor Of Terra From Gargoyle's Visceratika Discipline

### DIFF
--- a/code/modules/wod13/datums/powers/discipline/visceratika.dm
+++ b/code/modules/wod13/datums/powers/discipline/visceratika.dm
@@ -86,45 +86,40 @@
 	duration_length = 1 MINUTES
 
 /datum/discipline_power/visceratika/armor_of_terra/activate()
-	if(!active)
-		addtimer(CALLBACK(src, PROC_REF(deactivate)), duration_length * 3) //failsafe (no, you can't stay in statue mode forever, 3 mins is enough)
-		to_chat(owner, span_warning("You harden your skin far more than you're able to take for long!"))
-		ADD_TRAIT(owner, TRAIT_STUNIMMUNE, MAGIC)
-		ADD_TRAIT(owner, TRAIT_PUSHIMMUNE, MAGIC)
-		ADD_TRAIT(owner, TRAIT_NOBLEED, MAGIC_TRAIT)
-		ADD_TRAIT(owner, TRAIT_MUTE, STATUE_MUTE)
-		ADD_TRAIT(owner, TRAIT_IMMOBILIZED, MAGIC_TRAIT)
-		ADD_TRAIT(owner, TRAIT_HANDS_BLOCKED, MAGIC_TRAIT)
-
-		owner.name_override = "Statue of [owner.real_name]"
-		owner.status_flags |= GODMODE
-		var/newcolor = list(rgb(77,77,77), rgb(150,150,150), rgb(28,28,28), rgb(0,0,0))
-		owner.add_atom_colour(newcolor, FIXED_COLOUR_PRIORITY)
-
-		for(var/obj/stuff in owner.contents) //no stealing
-			ADD_TRAIT(stuff, TRAIT_NODROP, MAGIC)
-	else
-		deactivate()
-
 	. = ..()
+	addtimer(CALLBACK(src, PROC_REF(deactivate)), duration_length * 2) //failsafe (no, you can't stay in statue mode forever, 3 mins is enough)
+	to_chat(owner, span_warning("You harden your skin far more than you're able to take for long!"))
+	ADD_TRAIT(owner, TRAIT_STUNIMMUNE, MAGIC)
+	ADD_TRAIT(owner, TRAIT_PUSHIMMUNE, MAGIC)
+	ADD_TRAIT(owner, TRAIT_NOBLEED, MAGIC_TRAIT)
+	ADD_TRAIT(owner, TRAIT_MUTE, STATUE_MUTE)
+	ADD_TRAIT(owner, TRAIT_IMMOBILIZED, MAGIC_TRAIT)
+	ADD_TRAIT(owner, TRAIT_HANDS_BLOCKED, MAGIC_TRAIT)
+
+	owner.name_override = "Statue of [owner.real_name]"
+	owner.status_flags |= GODMODE
+	var/newcolor = list(rgb(77,77,77), rgb(150,150,150), rgb(28,28,28), rgb(0,0,0))
+	owner.add_atom_colour(newcolor, FIXED_COLOUR_PRIORITY)
+
+	for(var/obj/stuff in owner.contents) //no stealing
+		ADD_TRAIT(stuff, TRAIT_NODROP, MAGIC)
 
 /datum/discipline_power/visceratika/armor_of_terra/deactivate()
-	if(active)
-		to_chat(owner, span_warning("You soften your skin, to your normal hardness."))
-		REMOVE_TRAIT(owner, TRAIT_STUNIMMUNE, MAGIC)
-		REMOVE_TRAIT(owner, TRAIT_PUSHIMMUNE, MAGIC)
-		REMOVE_TRAIT(owner, TRAIT_NOBLEED, MAGIC_TRAIT)
-		REMOVE_TRAIT(owner, TRAIT_MUTE, STATUE_MUTE)
-		REMOVE_TRAIT(owner, TRAIT_IMMOBILIZED, MAGIC_TRAIT)
-		REMOVE_TRAIT(owner, TRAIT_HANDS_BLOCKED, MAGIC_TRAIT)
-
-		owner.name_override = null
-		owner.status_flags &= GODMODE
-		owner.remove_atom_colour(FIXED_COLOUR_PRIORITY)
-
-		for(var/obj/item/stuff in owner.contents)
-			REMOVE_TRAIT(stuff, TRAIT_NODROP, MAGIC)
 	. = ..()
+	to_chat(owner, span_warning("You soften your skin, to your normal hardness."))
+	REMOVE_TRAIT(owner, TRAIT_STUNIMMUNE, MAGIC)
+	REMOVE_TRAIT(owner, TRAIT_PUSHIMMUNE, MAGIC)
+	REMOVE_TRAIT(owner, TRAIT_NOBLEED, MAGIC_TRAIT)
+	REMOVE_TRAIT(owner, TRAIT_MUTE, STATUE_MUTE)
+	REMOVE_TRAIT(owner, TRAIT_IMMOBILIZED, MAGIC_TRAIT)
+	REMOVE_TRAIT(owner, TRAIT_HANDS_BLOCKED, MAGIC_TRAIT)
+
+	owner.name_override = null
+	owner.status_flags &= GODMODE
+	owner.remove_atom_colour(FIXED_COLOUR_PRIORITY)
+
+	for(var/obj/item/stuff in owner.contents)
+		REMOVE_TRAIT(stuff, TRAIT_NODROP, MAGIC)
 
 //FLOW WITHIN THE MOUNTAIN
 /datum/discipline_power/visceratika/flow_within_the_mountain

--- a/code/modules/wod13/datums/powers/discipline/visceratika.dm
+++ b/code/modules/wod13/datums/powers/discipline/visceratika.dm
@@ -77,7 +77,6 @@
 	desc = "Solidify into stone and become invulnerable."
 
 	level = 4
-	vitae_cost = 2
 	check_flags = DISC_CHECK_CONSCIOUS | DISC_CHECK_CAPABLE | DISC_CHECK_LYING
 
 	violates_masquerade = TRUE
@@ -94,7 +93,7 @@
 	is_statue = !is_statue //toggles it
 
 	if(is_statue)
-		addtimer(CALLBACK(src, PROC_REF(deactivate)), cooldown_length) //failsafe
+		addtimer(CALLBACK(src, PROC_REF(deactivate)), duration_length * 3) //failsafe
 		to_chat(owner, span_warning("You harden your skin far more than you're able to take for long!"))
 		ADD_TRAIT(owner, TRAIT_STUNIMMUNE, MAGIC)
 		ADD_TRAIT(owner, TRAIT_PUSHIMMUNE, MAGIC)

--- a/code/modules/wod13/datums/powers/discipline/visceratika.dm
+++ b/code/modules/wod13/datums/powers/discipline/visceratika.dm
@@ -85,13 +85,9 @@
 	cooldown_length = 1 MINUTES
 	duration_length = 1 MINUTES
 
-	///is the statue toggled or not
-	var/is_statue = FALSE
-
 /datum/discipline_power/visceratika/armor_of_terra/activate()
-	. = ..()
-	if(!is_statue)
-		addtimer(CALLBACK(src, PROC_REF(deactivate)), duration_length * 3) //failsafe
+	if(!active)
+		addtimer(CALLBACK(src, PROC_REF(deactivate)), duration_length * 3) //failsafe (no, you can't stay in statue mode forever, 3 mins is enough)
 		to_chat(owner, span_warning("You harden your skin far more than you're able to take for long!"))
 		ADD_TRAIT(owner, TRAIT_STUNIMMUNE, MAGIC)
 		ADD_TRAIT(owner, TRAIT_PUSHIMMUNE, MAGIC)
@@ -110,11 +106,10 @@
 	else
 		deactivate()
 
-	is_statue = !is_statue //toggles it
+	. = ..()
 
 /datum/discipline_power/visceratika/armor_of_terra/deactivate()
-	. = ..()
-	if(is_statue)
+	if(active)
 		to_chat(owner, span_warning("You soften your skin, to your normal hardness."))
 		REMOVE_TRAIT(owner, TRAIT_STUNIMMUNE, MAGIC)
 		REMOVE_TRAIT(owner, TRAIT_PUSHIMMUNE, MAGIC)
@@ -129,7 +124,7 @@
 
 		for(var/obj/item/stuff in owner.contents)
 			REMOVE_TRAIT(stuff, TRAIT_NODROP, MAGIC)
-			is_statue = FALSE
+	. = ..()
 
 //FLOW WITHIN THE MOUNTAIN
 /datum/discipline_power/visceratika/flow_within_the_mountain

--- a/code/modules/wod13/datums/powers/discipline/visceratika.dm
+++ b/code/modules/wod13/datums/powers/discipline/visceratika.dm
@@ -87,7 +87,7 @@
 
 /datum/discipline_power/visceratika/armor_of_terra/activate()
 	. = ..()
-	addtimer(CALLBACK(src, PROC_REF(deactivate)), duration_length * 2) //failsafe (no, you can't stay in statue mode forever, 3 mins is enough)
+	addtimer(CALLBACK(src, PROC_REF(try_deactivate), null, TRUE), duration_length * 2) //failsafe (no, you can't stay in statue mode forever, 3 mins is enough)
 	to_chat(owner, span_warning("You harden your skin far more than you're able to take for long!"))
 	ADD_TRAIT(owner, TRAIT_STUNIMMUNE, MAGIC)
 	ADD_TRAIT(owner, TRAIT_PUSHIMMUNE, MAGIC)

--- a/code/modules/wod13/datums/powers/discipline/visceratika.dm
+++ b/code/modules/wod13/datums/powers/discipline/visceratika.dm
@@ -77,17 +77,63 @@
 	desc = "Solidify into stone and become invulnerable."
 
 	level = 4
-	check_flags = DISC_CHECK_CONSCIOUS | DISC_CHECK_CAPABLE | DISC_CHECK_IMMOBILE | DISC_CHECK_LYING
+	vitae_cost = 2
+	check_flags = DISC_CHECK_CONSCIOUS | DISC_CHECK_CAPABLE | DISC_CHECK_LYING
 
 	violates_masquerade = TRUE
 
-	duration_length = 15 SECONDS
-	cooldown_length = 10 SECONDS
+	toggled = TRUE
+	cooldown_length = 2 MINUTES
+	duration_length = 1 MINUTES
+
+	///toggle if it's a statue or not
+	var/is_statue = FALSE
 
 /datum/discipline_power/visceratika/armor_of_terra/activate()
 	. = ..()
-	owner.Stun(duration_length)
-	owner.petrify(duration_length, "Visceratika")
+	is_statue = !is_statue //toggles it
+
+	if(is_statue)
+		addtimer(CALLBACK(src, PROC_REF(deactivate)), cooldown_length) //failsafe
+		to_chat(owner, span_warning("You harden your skin far more than you're able to take for long!"))
+		ADD_TRAIT(owner, TRAIT_STUNIMMUNE, MAGIC)
+		ADD_TRAIT(owner, TRAIT_PUSHIMMUNE, MAGIC)
+		ADD_TRAIT(owner, TRAIT_NOBLEED, MAGIC_TRAIT)
+		ADD_TRAIT(owner, TRAIT_MUTE, STATUE_MUTE)
+		ADD_TRAIT(owner, TRAIT_IMMOBILIZED, MAGIC_TRAIT)
+		ADD_TRAIT(owner, TRAIT_HANDS_BLOCKED, MAGIC_TRAIT)
+
+		owner.name = "Statue of [owner.real_name]"
+		owner.status_flags ^= GODMODE
+		var/newcolor = list(rgb(77,77,77), rgb(150,150,150), rgb(28,28,28), rgb(0,0,0))
+		owner.add_atom_colour(newcolor, FIXED_COLOUR_PRIORITY)
+
+		for(var/obj/stuff in owner.contents) //no stealing
+			ADD_TRAIT(stuff, TRAIT_NODROP, MAGIC)
+	else
+		unpetrify()
+
+/datum/discipline_power/visceratika/armor_of_terra/deactivate()
+	. = ..()
+	if(is_statue)
+		unpetrify()
+		is_statue = FALSE
+
+/datum/discipline_power/visceratika/armor_of_terra/proc/unpetrify()
+	to_chat(owner, span_warning("You soften your skin, to your normal hardness."))
+	REMOVE_TRAIT(owner, TRAIT_STUNIMMUNE, MAGIC)
+	REMOVE_TRAIT(owner, TRAIT_PUSHIMMUNE, MAGIC)
+	REMOVE_TRAIT(owner, TRAIT_NOBLEED, MAGIC_TRAIT)
+	REMOVE_TRAIT(owner, TRAIT_MUTE, STATUE_MUTE)
+	REMOVE_TRAIT(owner, TRAIT_IMMOBILIZED, MAGIC_TRAIT)
+	REMOVE_TRAIT(owner, TRAIT_HANDS_BLOCKED, MAGIC_TRAIT)
+
+	owner.name = owner.real_name
+	owner.status_flags ^= GODMODE
+	owner.remove_atom_colour(FIXED_COLOUR_PRIORITY)
+
+	for(var/obj/item/stuff in owner.contents)
+		REMOVE_TRAIT(stuff, TRAIT_NODROP, MAGIC)
 
 //FLOW WITHIN THE MOUNTAIN
 /datum/discipline_power/visceratika/flow_within_the_mountain

--- a/code/modules/wod13/datums/powers/discipline/visceratika.dm
+++ b/code/modules/wod13/datums/powers/discipline/visceratika.dm
@@ -85,14 +85,12 @@
 	cooldown_length = 2 MINUTES
 	duration_length = 1 MINUTES
 
-	///toggle if it's a statue or not
+	///is the statue toggled or not
 	var/is_statue = FALSE
 
 /datum/discipline_power/visceratika/armor_of_terra/activate()
 	. = ..()
-	is_statue = !is_statue //toggles it
-
-	if(is_statue)
+	if(!is_statue)
 		addtimer(CALLBACK(src, PROC_REF(deactivate)), duration_length * 3) //failsafe
 		to_chat(owner, span_warning("You harden your skin far more than you're able to take for long!"))
 		ADD_TRAIT(owner, TRAIT_STUNIMMUNE, MAGIC)
@@ -103,7 +101,7 @@
 		ADD_TRAIT(owner, TRAIT_HANDS_BLOCKED, MAGIC_TRAIT)
 
 		owner.name = "Statue of [owner.real_name]"
-		owner.status_flags ^= GODMODE
+		owner.status_flags |= GODMODE
 		var/newcolor = list(rgb(77,77,77), rgb(150,150,150), rgb(28,28,28), rgb(0,0,0))
 		owner.add_atom_colour(newcolor, FIXED_COLOUR_PRIORITY)
 
@@ -111,6 +109,8 @@
 			ADD_TRAIT(stuff, TRAIT_NODROP, MAGIC)
 	else
 		unpetrify()
+
+	is_statue = !is_statue //toggles it
 
 /datum/discipline_power/visceratika/armor_of_terra/deactivate()
 	. = ..()
@@ -128,7 +128,7 @@
 	REMOVE_TRAIT(owner, TRAIT_HANDS_BLOCKED, MAGIC_TRAIT)
 
 	owner.name = owner.real_name
-	owner.status_flags ^= GODMODE
+	owner.status_flags &= GODMODE
 	owner.remove_atom_colour(FIXED_COLOUR_PRIORITY)
 
 	for(var/obj/item/stuff in owner.contents)

--- a/code/modules/wod13/datums/powers/discipline/visceratika.dm
+++ b/code/modules/wod13/datums/powers/discipline/visceratika.dm
@@ -87,7 +87,7 @@
 
 /datum/discipline_power/visceratika/armor_of_terra/activate()
 	. = ..()
-	addtimer(CALLBACK(src, PROC_REF(try_deactivate), null, TRUE), duration_length * 2) //failsafe (no, you can't stay in statue mode forever, 3 mins is enough)
+	addtimer(CALLBACK(src, PROC_REF(try_deactivate), null, TRUE), duration_length * 2) //failsafe (no, you can't stay in statue mode forever, 2 mins is enough)
 	to_chat(owner, span_warning("You harden your skin far more than you're able to take for long!"))
 	ADD_TRAIT(owner, TRAIT_STUNIMMUNE, MAGIC)
 	ADD_TRAIT(owner, TRAIT_PUSHIMMUNE, MAGIC)

--- a/code/modules/wod13/datums/powers/discipline/visceratika.dm
+++ b/code/modules/wod13/datums/powers/discipline/visceratika.dm
@@ -82,7 +82,7 @@
 	violates_masquerade = TRUE
 
 	toggled = TRUE
-	cooldown_length = 2 MINUTES
+	cooldown_length = 1 MINUTES
 	duration_length = 1 MINUTES
 
 	///is the statue toggled or not
@@ -100,7 +100,7 @@
 		ADD_TRAIT(owner, TRAIT_IMMOBILIZED, MAGIC_TRAIT)
 		ADD_TRAIT(owner, TRAIT_HANDS_BLOCKED, MAGIC_TRAIT)
 
-		owner.name = "Statue of [owner.real_name]"
+		owner.name_override = "Statue of [owner.real_name]"
 		owner.status_flags |= GODMODE
 		var/newcolor = list(rgb(77,77,77), rgb(150,150,150), rgb(28,28,28), rgb(0,0,0))
 		owner.add_atom_colour(newcolor, FIXED_COLOUR_PRIORITY)
@@ -108,31 +108,28 @@
 		for(var/obj/stuff in owner.contents) //no stealing
 			ADD_TRAIT(stuff, TRAIT_NODROP, MAGIC)
 	else
-		unpetrify()
+		deactivate()
 
 	is_statue = !is_statue //toggles it
 
 /datum/discipline_power/visceratika/armor_of_terra/deactivate()
 	. = ..()
 	if(is_statue)
-		unpetrify()
-		is_statue = FALSE
+		to_chat(owner, span_warning("You soften your skin, to your normal hardness."))
+		REMOVE_TRAIT(owner, TRAIT_STUNIMMUNE, MAGIC)
+		REMOVE_TRAIT(owner, TRAIT_PUSHIMMUNE, MAGIC)
+		REMOVE_TRAIT(owner, TRAIT_NOBLEED, MAGIC_TRAIT)
+		REMOVE_TRAIT(owner, TRAIT_MUTE, STATUE_MUTE)
+		REMOVE_TRAIT(owner, TRAIT_IMMOBILIZED, MAGIC_TRAIT)
+		REMOVE_TRAIT(owner, TRAIT_HANDS_BLOCKED, MAGIC_TRAIT)
 
-/datum/discipline_power/visceratika/armor_of_terra/proc/unpetrify()
-	to_chat(owner, span_warning("You soften your skin, to your normal hardness."))
-	REMOVE_TRAIT(owner, TRAIT_STUNIMMUNE, MAGIC)
-	REMOVE_TRAIT(owner, TRAIT_PUSHIMMUNE, MAGIC)
-	REMOVE_TRAIT(owner, TRAIT_NOBLEED, MAGIC_TRAIT)
-	REMOVE_TRAIT(owner, TRAIT_MUTE, STATUE_MUTE)
-	REMOVE_TRAIT(owner, TRAIT_IMMOBILIZED, MAGIC_TRAIT)
-	REMOVE_TRAIT(owner, TRAIT_HANDS_BLOCKED, MAGIC_TRAIT)
+		owner.name_override = null
+		owner.status_flags &= GODMODE
+		owner.remove_atom_colour(FIXED_COLOUR_PRIORITY)
 
-	owner.name = owner.real_name
-	owner.status_flags &= GODMODE
-	owner.remove_atom_colour(FIXED_COLOUR_PRIORITY)
-
-	for(var/obj/item/stuff in owner.contents)
-		REMOVE_TRAIT(stuff, TRAIT_NODROP, MAGIC)
+		for(var/obj/item/stuff in owner.contents)
+			REMOVE_TRAIT(stuff, TRAIT_NODROP, MAGIC)
+			is_statue = FALSE
 
 //FLOW WITHIN THE MOUNTAIN
 /datum/discipline_power/visceratika/flow_within_the_mountain


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This bounty PR reworks Armor Of Terra, making it so that, instead of making you into a statue structure, it instead turns you functionally int a statue... if that make sense.

Essentially turns you grey, mute, immobile, godmode for the duration of the ability.

It's a toggle, consuming 1 blood per minute with a maximum duration of in a statue of three minutes. enough time for help to arrive, hopefully anyways. also a cooldown between deactivation and activation of two minutes.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
At the moment, gargoyles can become via viseratika 4 a statue that they cannot leave for 3 minutes, nor emote or act as said statue. This seems really half-assed, especially since it's not a toggle you can control and not all that useful.

This reworks it to be less jank, and at least adds a tiny bit more usability
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
Here's a video from a couple of months ago from when I was JUST about to PR this PR, before realizing it was pushed back until yesteday. some minor changes but the gist is the same: https://youtu.be/OU9MlSlHkMw
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Reworks Armor Of Terra From Gargoyle's Visceratika Discipline
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
