### PR TITLE
Update __byond_version_compat.dm

### DIFF
--- a/code/__byond_version_compat.dm
+++ b/code/__byond_version_compat.dm
@@ -1,8 +1,8 @@
 // This file contains defines allowing targeting byond versions newer than the supported
 
 //Update this whenever you need to take advantage of more recent byond features
-#define MIN_COMPILER_VERSION 516
-#define MIN_COMPILER_BUILD 1658
+#define MIN_COMPILER_VERSION 514
+#define MIN_COMPILER_BUILD 1589
 #if (DM_VERSION < MIN_COMPILER_VERSION || DM_BUILD < MIN_COMPILER_BUILD) && !defined(SPACEMAN_DMM)
 //Don't forget to update this part
 #error Your version of BYOND is too out-of-date to compile this project. Go to https://secure.byond.com/download and update.


### PR DESCRIPTION
Pushes back the minimum required compiler to whats on the server which in theory at least should not matter for the purpose of 516 client side compatibility, since its mostly hylperlinks and jsx.