### PR TITLE
Potential icon and runechat flickering fix

### DIFF
--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -199,6 +199,7 @@
 	// View the message
 	LAZYADDASSOC(owned_by.seen_messages, message_loc, src)
 	owned_by.images |= message
+	animate(message, alpha = 0, time = 0) // Temp fix for chat flickering issue
 	animate(message, alpha = 255, time = CHAT_MESSAGE_SPAWN_TIME)
 
 	// Register with the runechat SS to handle EOL and destruction

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -191,6 +191,8 @@
 	message.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA | KEEP_APART
 	message.alpha = 0
 	message.pixel_y = owner.bound_height * 0.95
+	animate(message, alpha = 0, pixel_y = owner.bound_height * 0.95,  time = 1)
+	sleep(1)
 	message.maptext_width = CHAT_MESSAGE_WIDTH
 	message.maptext_height = mheight
 	message.maptext_x = (CHAT_MESSAGE_WIDTH - owner.bound_width) * -0.5
@@ -198,8 +200,7 @@
 
 	// View the message
 	LAZYADDASSOC(owned_by.seen_messages, message_loc, src)
-	owned_by.images |= message
-	animate(message, alpha = 0, time = 0) // Temp fix for chat flickering issue
+	owned_by.images += message// Temp fix for chat flickering issue
 	animate(message, alpha = 255, time = CHAT_MESSAGE_SPAWN_TIME)
 
 	// Register with the runechat SS to handle EOL and destruction

--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -114,6 +114,7 @@
 	bar.pixel_y = 0
 	bar.alpha = 0
 	user_client.images += bar
+	animate(bar, alpha = 0, time = 0) // temporary fix to flickering issue
 	animate(bar, pixel_y = 32 + (PROGRESSBAR_HEIGHT * (listindex - 1)), alpha = 255, time = PROGRESSBAR_ANIMATION_TIME, easing = SINE_EASING)
 
 

--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -106,15 +106,16 @@
 	if(!user.client) //Clients can vanish at any time, the bastards.
 		return
 	user_client = user.client
-	add_prog_bar_image_to_client()
+	INVOKE_ASYNC(src, PROC_REF(add_prog_bar_image_to_client))
 
 
 ///Adds a smoothly-appearing progress bar image to the player's screen.
 /datum/progressbar/proc/add_prog_bar_image_to_client()
 	bar.pixel_y = 0
 	bar.alpha = 0
+	animate(bar, alpha = 0, pixel_y = 0, time = 1)
+	sleep(1) // temporary fix to flickering issue
 	user_client.images += bar
-	animate(bar, alpha = 0, time = 0) // temporary fix to flickering issue
 	animate(bar, pixel_y = 32 + (PROGRESSBAR_HEIGHT * (listindex - 1)), alpha = 255, time = PROGRESSBAR_ANIMATION_TIME, easing = SINE_EASING)
 
 


### PR DESCRIPTION
This attempts to fix the current client side bug where images sent to the client do not properly retain their transformation vars, so they flicker before they are "snapped" to their intended value by an animate() call.

In essence this puts dummy 1 tick animate calls while the image is being prepped and sleeps the prep for 1 tick to make sure the animation runs before the image is sent to the client. Images transformed by animate() seem to reatain their intended values client side.