### PR TITLE
Tweaks frequency/severity of Malkavian Halluciantions

### DIFF
--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -31,7 +31,7 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 	var/halpick = pickweight(GLOB.hallucination_list)
 	new halpick(src, FALSE)
 
-	next_hallucination = world.time + rand(100, 600)
+	next_hallucination = world.time + rand(1 MINUTES, 3 MINUTES)
 
 /mob/living/carbon/proc/set_screwyhud(hud_type)
 	hal_screwyhud = hud_type

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -1,9 +1,9 @@
 #define HAL_LINES_FILE "hallucination.json"
 
 GLOBAL_LIST_INIT(hallucination_list, list(
-	/datum/hallucination/chat = 100,
-	/datum/hallucination/message = 60,
-	/datum/hallucination/sounds = 50,
+	/datum/hallucination/chat = 30,
+	/datum/hallucination/message = 30,
+	/datum/hallucination/sounds = 20,
 	/datum/hallucination/battle = 20,
 	/datum/hallucination/dangerflash = 15,
 	/datum/hallucination/weird_sounds = 8,


### PR DESCRIPTION
Currently the hallucination value rests at 100 to 600 ticks, or 10 to 60 seconds. This means that in solo conversations, Malkavians can literally get overwhelmed by the hallucination chat spam.  I've seen chat logs with 5-10 hallucination lines between player lines. 

Some math: Assuming a 120 minute round, with the current setting, a particularly unlucky Malkavian can go through 720 events and the average oscillating somewhere around 300.

I set the setting to 1 and 3 minutes, still meaning 40-120 events in a two hour round round and additionally cut down the chance of the chat, message and sound hallucinations happening by a similar factor, meaning that the rarer ones will happen more frequently.

Ideally this result in slightly less of the "big" hallucinations happening, but not significantly less but way, WAY less chat spam.