### PR TITLE
delivery quick fixes

### DIFF
--- a/_maps/map_files/Vampire/SanFrancisco.dmm
+++ b/_maps/map_files/Vampire/SanFrancisco.dmm
@@ -43076,7 +43076,8 @@
 /area/vtm/sewer)
 "juR" = (
 /obj/machinery/vending/sustenance{
-	pixel_y = 18
+	pixel_y = 18;
+	density = 0
 	},
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/millennium_tower)
@@ -56583,7 +56584,8 @@
 "pSP" = (
 /obj/structure/reagent_dispensers/water_cooler{
 	pixel_x = -6;
-	pixel_y = 20
+	pixel_y = 20;
+	density = 0
 	},
 /turf/open/floor/plating/vampplating,
 /area/vtm/interior/millennium_tower)

--- a/code/modules/wod13/delivery/delivery_datums.dm
+++ b/code/modules/wod13/delivery/delivery_datums.dm
@@ -283,15 +283,15 @@
 		if(1)
 			assign_recievers(3)
 			assign_crates(3,6)
-			delivery_set_timer(15 MINUTES)
+			delivery_set_timer(20 MINUTES)
 		if(2)
 			assign_recievers(5)
 			assign_crates(7,10)
-			delivery_set_timer(25 MINUTES)
+			delivery_set_timer(45 MINUTES)
 		if(3)
 			assign_recievers(7)
 			assign_crates(9,15)
-			delivery_set_timer(40 MINUTES)
+			delivery_set_timer(90 MINUTES)
 	return 1
 
 /datum/delivery_datum/New(mob/user,obj/board_ref,difficulty)
@@ -542,7 +542,7 @@
 				if(turf_list.Find(tested_turf) == 0)
 					turf_list.Add(tested_turf)
 		if(turf_list.len != 0)
-			html += "<p><b>Active Crates:</b>"
+			html += "<p><b>Active Crates:</b><br>"
 			for(var/turf/picked_turf in turf_list)
 				html += "X:[picked_turf.x] Y:[picked_turf.y] Z:[picked_turf.z]<br>"
 				html += "</p>"

--- a/code/modules/wod13/delivery/delivery_objs.dm
+++ b/code/modules/wod13/delivery/delivery_objs.dm
@@ -64,6 +64,19 @@
 
 	. = ..()
 
+/obj/item/delivery_contract/attack_hand(mob/user)
+	if(!delivery)
+		to_chat(user,span_notice("Error: No delivery datum attached. This is most likely a bug."))
+		return
+	if(!manifest) return "no_manifest"
+
+	if(delivery.check_owner(user) == 0)
+		to_chat(user, span_warning("You are not listed on this manifest. Before you can use it, one of its owners needs to add you to the crew handling it by using the manifest on you."))
+	else
+		manifest.read_data(user)
+	. = ..()
+
+
 /obj/item/delivery_contract/Destroy()
 	. = ..()
 	if(delivery) qdel(delivery)
@@ -101,13 +114,13 @@
 				switch(tgui_input_list(user,"Select a contract length, details will be outlined before accepting.","Contract Selection",list("Short","Medium","Long"),timeout = 10 SECONDS))
 					if("Short")
 						picked_difficulty = 1
-						difficulty_text = "A short contract involves 3 locations with up to 6 crates each, meaning the entire delivery can be completed with one truck. The time limit is 15 minutes."
+						difficulty_text = "A short contract involves 3 locations with up to 6 crates each, meaning the entire delivery can be completed with one truck. The time limit is 20 minutes."
 					if("Medium")
 						picked_difficulty = 2
-						difficulty_text = "A medium contract involves 5 locations with up to 10 crates each, the entire delivery should be completed in 3 runs. The time limit is 25 minutes. "
+						difficulty_text = "A medium contract involves 5 locations with up to 10 crates each, the entire delivery should be completed in 3 runs. The time limit is 45 minutes. "
 					if("Long")
 						picked_difficulty = 3
-						difficulty_text = "A long contract involves 7 locations with up to 15 crates each, meaning that without partial loads each delivery will require a restock. The timie limit is 40 minutes."
+						difficulty_text = "A long contract involves 7 locations with up to 15 crates each, meaning that without partial loads each delivery will require a restock. The timie limit is 90 minutes."
 				if(tgui_alert(user,difficulty_text,"Confirm Contract",list("Yes","No"),timeout = 10 SECONDS) == "Yes")
 					var/obj/item/delivery_contract/contract = new(user,src,picked_difficulty)
 					switch(contract.delivery.start_contract())
@@ -317,6 +330,9 @@
 		return
 	if(dispenser_in_use == 1)
 		to_chat(user, span_warning("Someone is already using this dispenser!"))
+		return
+	if(user.pulling == null)
+		to_chat(user, span_notice("It appears that you need to use a key to operate this dispenser. If you are on a delivery, use the key you got when you signed up or were added to the contract."))
 		return
 	if(user.pulling != null)
 		if(istype(user.pulling, /obj/structure/delivery_crate))


### PR DESCRIPTION
Post implementation quick fixes: 
- Greatly extended delivery time limits
- Dispensers show more feedback when used without a key
- Added missing breakpoint to contract readout
- Contracts should now be useable from the inventory, not only by attacking oneself with them
- Makes the vending machine and water cooler in the Tower Lobby not have density since they are shifted against the wall.