### PR TITLE
Puts full flavor text back in the look results

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -497,16 +497,19 @@
 		. += "<a href='byond://?src=[REF(src)];masquerade=1'>Spot a Masquerade violation</a>"
 
 	var/flavor_text_link
-	var/preview_text = copytext_char(flavor_text, 1, 110)
+	var/desc_output
+	if(flavor_text) desc_output = "[flavor_text]"
 	// What examine_tgui.dm uses to determine if flavor text appears as "Obscured".
 	var/face_obscured = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
-
+	. += "*---------*"
 	if (!(face_obscured))
-		flavor_text_link = span_notice("[preview_text]... <a href='byond://?src=[REF(src)];view_flavortext=1'>\[Look closer?\]</a>")
+		if(ooc_notes) flavor_text_link = span_notice("<a href='byond://?src=[REF(src)];view_flavortext=1'>\[OOC Information\]</a>")
 	else
 		flavor_text_link = span_notice("<a href='byond://?src=[REF(src)];view_flavortext=1'>\[Examine closely...\]</a>")
 	if (flavor_text_link)
-		. += flavor_text_link
+		desc_output += "[flavor_text_link]"
+	if(desc_output)
+		. += desc_output
 
 	var/perpname = get_face_name(get_id_name(""))
 	if(perpname && (HAS_TRAIT(user, TRAIT_SECURITY_HUD) || HAS_TRAIT(user, TRAIT_MEDICAL_HUD)))

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -503,7 +503,7 @@
 	var/face_obscured = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
 	. += "*---------*"
 	if (!(face_obscured))
-		if(ooc_notes) flavor_text_link = span_notice("<a href='byond://?src=[REF(src)];view_flavortext=1'>\[OOC Information\]</a>")
+		if(ooc_notes) flavor_text_link = span_notice("<br><a href='byond://?src=[REF(src)];view_flavortext=1'>\[OOC Information\]</a>")
 	else
 		flavor_text_link = span_notice("<a href='byond://?src=[REF(src)];view_flavortext=1'>\[Examine closely...\]</a>")
 	if (flavor_text_link)


### PR DESCRIPTION
After playing some rounds with the new tgui descriptions, I completely hate the fact that flavor text is now cut off after 100 chars in the look menu. It seems like throwing it into a separate popup all but guarantees that no one reads them and that's not the intent here I think.

As such

- The look dialog now displays the whole flavor text
- The tgui examine link appears only if the person being examined has their face obscured and/or has ooc flavor set.

This takes care of the cases where the dialog is actually useful, but keeps the descriptions where they imo belong.

Tested locally, all was fine. 