### PR TITLE
Fixes layering of repaired doors 

### DIFF
--- a/code/modules/wod13/structures/doors/vampdoor.dm
+++ b/code/modules/wod13/structures/doors/vampdoor.dm
@@ -109,7 +109,7 @@
 	door_broken = 0
 	density = 1
 	if(!glass) opacity = 1
-	layer = OPEN_DOOR_LAYER
+	layer = ABOVE_ALL_MOB_LAYER
 	closed = TRUE
 	locked = FALSE
 	icon_state = "[baseicon]-1"


### PR DESCRIPTION
Small whoopsie, doors need to be opened then closed again to be layered properly and dont draw under mobs.

This fixes that :U