### PR TITLE
Bails on the bailers in botany.

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates/wooden.dm
+++ b/code/game/objects/structures/crates_lockers/crates/wooden.dm
@@ -38,7 +38,7 @@
 	new	/obj/item/shovel/spade(src)
 	new	/obj/item/cultivator(src)
 	new	/obj/item/clothing/gloves/botanic_leather(src)
-	new	/obj/item/bailer(src)
+	new	/obj/item/reagent_containers/glass/bucket/wooden(src)
 
 /obj/structure/closet/crate/wooden/communitygardens/seeds
 	name = "community garden seeds"


### PR DESCRIPTION
Bailers don't work on the trays. 

Buckets do.

- Replaced bailers in botany map spawn crates with buckets.