### PR TITLE
Makes keys work on garage doors, changes Camarilla limo access

### DIFF
--- a/_maps/map_files/Vampire/SanFrancisco.dmm
+++ b/_maps/map_files/Vampire/SanFrancisco.dmm
@@ -7820,7 +7820,7 @@
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
 /obj/machinery/button/door{
-	id = "armouryaccess";
+	id = "police";
 	name = "Parking Shutters Control"
 	},
 /turf/open/floor/plating/asphalt,
@@ -8448,7 +8448,7 @@
 "aDk" = (
 /obj/machinery/door/poddoor/shutters{
 	damage_deflection = 60;
-	id = "armouryaccess";
+	id = "police";
 	max_integrity = 300;
 	name = "Parking Shutter"
 	},
@@ -14046,7 +14046,7 @@
 "aWD" = (
 /obj/structure/table,
 /obj/machinery/button/door{
-	id = "prince";
+	id = "camarilla";
 	name = "Parking Shutters Control"
 	},
 /obj/effect/decal/rugs,
@@ -33583,7 +33583,9 @@
 /turf/open/floor/plating/vampgrass,
 /area/vtm/pacificheights)
 "fgN" = (
-/obj/vampire_car/limousine/camarilla,
+/obj/vampire_car/limousine/camarilla{
+	access = "theatre"
+	},
 /turf/open/floor/plating/asphalt,
 /area/vtm/interior/millennium_tower)
 "fgX" = (
@@ -52763,7 +52765,7 @@
 "nUJ" = (
 /obj/machinery/door/poddoor/shutters{
 	damage_deflection = 60;
-	id = "prince";
+	id = "camarilla";
 	max_integrity = 300;
 	name = "Parking Shutter"
 	},

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -20,6 +20,16 @@
 
 /obj/machinery/door/poddoor/attackby(obj/item/W, mob/user, params)
 	. = ..()
+
+	if(istype(W,/obj/item/vamp/keys) == 1)
+		var/obj/item/vamp/keys/key = W
+		if(key.accesslocks.Find(id) != 0)
+			var/area/current_area = get_area(src)
+			for(var/obj/machinery/button/door/door_button in current_area)
+				if(door_button.id == id)
+					door_button.device.pulsed()
+					break
+
 	if(ertblast && W.tool_behaviour == TOOL_SCREWDRIVER) // This makes it so ERT members cannot cheese by opening their blast doors.
 		to_chat(user, "<span class='warning'>This shutter has a different kind of screw, you cannot unscrew the panel open.</span>")
 		return


### PR DESCRIPTION
Keys can now be used to open/close garage shutters when used directly on them. This makes it so authorized users don't have to go look for the damn button, then go around to the car since they cant use the closed shutters now.

Also, the Camarilla limo is now only openable by those with Theater access, so the Sheriff, Seneschal and Prince. No more joyriding.

Tested locally, everything checked out.