### PR TITLE
Adusts padding on about me screen and fixes neutral gender display

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -33,6 +33,8 @@
 				my_gender = "lady"
 			if(24 to INFINITY)
 				my_gender = "woman"
+	if(gender == PLURAL || gender == NEUTER)
+		my_gender = "person"
 	if(my_shape == "s")
 		my_shape = "slim"
 	if(my_shape == "f")

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -25,7 +25,7 @@
 			<style type="text/css">
 
 			body {
-				padding: 1em;
+				padding: 5px;
 				background-color: #090909; color: white;
 			}
 

--- a/code/modules/vtmb/ghoul_species.dm
+++ b/code/modules/vtmb/ghoul_species.dm
@@ -32,7 +32,7 @@
 			<style type="text/css">
 
 			body {
-				padding: 1em;
+				padding: 5px;
 				background-color: #090909; color: white;
 			}
 

--- a/code/modules/vtmb/kindred_species.dm
+++ b/code/modules/vtmb/kindred_species.dm
@@ -48,7 +48,7 @@
 			<style type="text/css">
 
 			body {
-				padding: 1em;
+				padding: 5px;
 				background-color: #090909; color: white;
 			}
 

--- a/code/modules/vtmb/kuei_jin.dm
+++ b/code/modules/vtmb/kuei_jin.dm
@@ -142,7 +142,7 @@
 			<style type="text/css">
 
 			body {
-				padding: 1em;
+				padding: 5px;
 				background-color: #090909; color: white;
 			}
 

--- a/code/modules/vtmb/werewolf_species.dm
+++ b/code/modules/vtmb/werewolf_species.dm
@@ -30,7 +30,7 @@
 			<style type="text/css">
 
 			body {
-				padding: 1em;
+				padding: 5px;
 				background-color: #090909; color: white;
 			}
 


### PR DESCRIPTION
Random touchups that don't fit anywhere else:

- Adjusts padding on about me screen to compensate for smaller resolution displays.
- Characters with a neutral gender are now identified as a person, not male.

Tested locally etc etc.
