### PR TITLE
Removes pop scaling from global masquerade calculations

### DIFF
--- a/code/modules/vtmb/gamemodes/masquerade.dm
+++ b/code/modules/vtmb/gamemodes/masquerade.dm
@@ -7,7 +7,7 @@ SUBSYSTEM_DEF(masquerade)
 	var/total_level = 1000
 	var/dead_level = 0
 	var/last_level = "stable"
-	var/manual_adjustment = 0 
+	var/manual_adjustment = 0
 
 /datum/controller/subsystem/masquerade/proc/get_description()
 	switch(total_level)
@@ -24,9 +24,9 @@ SUBSYSTEM_DEF(masquerade)
 	var/masquerade_violators = 0
 	var/sabbat = 0
 	if(length(GLOB.masquerade_breakers_list))
-		masquerade_violators = (2000/length(GLOB.player_list))*length(GLOB.masquerade_breakers_list)
+		masquerade_violators = GLOB.masquerade_breakers_list.len * 100
 	if(length(GLOB.sabbatites))
-		sabbat = (2000/length(GLOB.player_list))*length(GLOB.sabbatites)
+		sabbat = GLOB.sabbatites.len * 100
 
 	total_level = max(0, min(1000, 1000 + dead_level + manual_adjustment - masquerade_violators - sabbat))
 


### PR DESCRIPTION
Currently one Sabbatite or Masqu breaker joining in low pop can literally swat the entire server. Conversely, on high pop this makes those decreases next to unnoticeable. 

Replaced with a flat 100 per masqu breacher and sabatitie, to be revised should we have higher numbers again.

- Each Sabbatite and Masquerade Breacher now reduces the global masquerade by a flat 100 instead of very odd values scaled by population. No more singlehandedly tanking the masquerade to 0.