### PR TITLE
Fixes the 2 runtimes that show up on guest login.

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -311,7 +311,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	//we couldn't load character data so just randomize the character appearance + name
 	random_species()
 	random_character()		//let's create a random character then - rather than a fat, bald and naked man.
-	reset_shit()
+	if(!IsGuestKey(C.key)) reset_shit()
 	key_bindings = deepCopyList(GLOB.hotkey_keybinding_list_by_key) // give them default keybinds and update their movement keys
 	C?.set_macros()
 //	pref_species = new /datum/species/kindred()

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -53,7 +53,11 @@
 		body_type = pick(MALE, FEMALE)
 
 /datum/preferences/proc/random_species()
-	var/random_species_type = GLOB.species_list[pick(GLOB.roundstart_races)]
+	var/random_species_type
+	if(GLOB.roundstart_races.len != 0)
+		random_species_type = GLOB.species_list[pick(GLOB.roundstart_races)]
+	else
+		random_species_type = GLOB.species_list["human"]
 	pref_species = new random_species_type
 	if(randomise[RANDOM_NAME])
 		real_name = pref_species.random_name(gender,1)


### PR DESCRIPTION
This is particularly annoying during local testing as it halts the server starting up not once but twice. Say someone pushes F5 and walks away for a while forgetting these happened. Cough.

Also, runtimes are bad.

-Fixes the two runtimes that show up (and stop loading dead in its tracks, waiting for user input) whenever a Guest user logs into a local instance. 